### PR TITLE
fix: setup.py can now find numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 from setuptools import setup, Extension
-import numpy
+from setuptools.command.build_ext import build_ext as _build_ext
 from fastgrab import metadata
 
 module_info = Extension(
     "fastgrab._linux_x11",
-    include_dirs=[numpy.get_include()],
+    include_dirs=[],  # Populated by build_ext().
     libraries=['X11', 'gomp'],
     extra_compile_args=[
         '-fno-strict-aliasing',
@@ -15,6 +15,17 @@ module_info = Extension(
     sources=["fastgrab/linux_x11/screenshot.c"]
 )
 
+class build_ext(_build_ext):
+    def finalize_options(self):
+        _build_ext.finalize_options(self)
+        # Prevent numpy from thinking it's still in its setup process.
+        # NOTE: Doesn't exist in modern numpy versions.
+        if "__NUMPY_SETUP__" in __builtins__:
+            __builtins__.__NUMPY_SETUP__ = False
+        # Add the numpy header directory to our build process.
+        import numpy
+        self.include_dirs.append(numpy.get_include())
+
 setup(
     name=metadata.package,
     version=metadata.version,
@@ -22,5 +33,7 @@ setup(
     author=metadata.authors,
     url=metadata.url,
     packages=[metadata.package],
+    cmdclass={'build_ext':build_ext},
+    setup_requires=['numpy'],
     ext_modules=[module_info]
 )


### PR DESCRIPTION
The old setup.py code was unable to build the fastgrab module, due to missing numpy during the setup stage. It's unlikely that anyone ever installed this library via PyPi in the past, due to this oversight.

However, it's possible to patch the build process class to do late injection of the numpy headers path. This technique comes from the following post:

https://stackoverflow.com/a/21621689/8874388

It works by telling setuptools that we need numpy, and then modifying the build process class to add numpy's path before we actually build fastgrab.

Further fixes were performed to make it buildable on Python 3.12 with the latest libraries.

Closes #18.