### PR TITLE
packaging: keep IDE leftovers and stale builds out of the sdist/wheel

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,14 +15,14 @@
 
 ifeq ($(docker),1)
 DC := docker compose run --rm --entrypoint bash test -c
-BUILD_CMD := $(DC) 'poetry build'
+BUILD_CMD := $(DC) 'rm -f fastgrab/*.so && poetry build'
 TEST_CMD := docker compose run --rm test
 TEST_WAYLAND_CMD := docker compose run --rm test-wayland
 INSTALL_CMD := $(DC) 'poetry install --extras gui'
 BENCH_CMD := docker compose run --rm benchmark
 LOCK_CMD := $(DC) 'poetry lock'
 else
-BUILD_CMD := poetry build
+BUILD_CMD := rm -f fastgrab/*.so && poetry build
 TEST_CMD := pytest -m 'not wayland' tests
 TEST_WAYLAND_CMD := pytest -m wayland tests
 INSTALL_CMD := poetry install --extras gui
@@ -67,10 +67,10 @@ lock:
 #@help: remove build artifacts (also docker compose volumes when docker=1)
 clean:
 ifeq ($(docker),1)
-	-docker run --rm -v "$(CURDIR)":/work -w /work alpine sh -c 'rm -rf dist build *.egg-info'
+	-docker run --rm -v "$(CURDIR)":/work -w /work alpine sh -c 'rm -rf dist build *.egg-info fastgrab/*.so'
 	-docker compose down -v
 else
-	rm -rf dist build *.egg-info
+	rm -rf dist build *.egg-info fastgrab/*.so
 endif
 
 define AWK_SCRIPT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,18 @@ include = [
     {path = "fastgrab/backends/protocols/*.xml", format = ["sdist", "wheel"]},
     {path = "fastgrab/backends/protocols/*.py", format = ["sdist", "wheel"]},
 ]
+# Explicit excludes: Poetry only honours .gitignore when git is available,
+# and the dev container (where `make build docker=1` runs) has none — so
+# IDE leftovers and caches under fastgrab/ would otherwise be packaged into
+# the sdist AND the wheel. Stale in-place *.so builds can't be excluded by
+# pattern (the build hook's fresh output has the same name and must be
+# packaged), so `make build` deletes them before invoking poetry.
+exclude = [
+    "fastgrab/**/__pycache__",
+    "fastgrab/linux_x11/cmake-build-debug",
+    "fastgrab/linux_x11/.idea",
+    "fastgrab/linux_x11/CMakeLists.txt",
+]
 build = "build.py"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Found while building the 0.3.0 sdist: the dev container has no `git`, so Poetry could not apply `.gitignore` and packaged the 2019 CLion tree (`cmake-build-debug/` incl. `a.out` binaries, `.idea/`, `CMakeLists.txt`) and the host's stale in-place `*.so` into both the sdist and the wheel.

- `pyproject.toml`: explicit `exclude` for the IDE leftovers and `__pycache__`.
- `Makefile`: `build` deletes `fastgrab/*.so` before `poetry build`; `clean` removes them too.

Verified: sdist = git-tracked files + PKG-INFO only; wheel has exactly one `.so`; `pip install` of the sdist in a fresh `python:3.12-slim` compiles and captures `(480, 640, 4)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLmJd7aNG8CRS7EQ9waLqD
