### PR TITLE
macOS: capture in device pixels instead of points on Retina displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,10 @@ Per-platform extras:
    GDI ``BitBlt`` via ``ctypes``.
  - **macOS**: nothing beyond Python + numpy. macOS 10.15+ requires
    *Screen Recording* permission for the running app (System Settings →
-   Privacy & Security).
+   Privacy & Security). Captures are in **device pixels**, so a Retina
+   display reports (and returns) the full backing store — a 1800x1169
+   desktop captures as 3600x2338. ``bbox`` rectangles are in device
+   pixels too.
 
 note that ``fastgrab`` could work with lower versions but I have not tested it
 (and probaby will not). 

--- a/agents/fastgrab-dev.md
+++ b/agents/fastgrab-dev.md
@@ -176,6 +176,8 @@ immediately; the entrypoint rebuilds the C extension in place on start.
 | `tests/test_integration.py` | `@pytest.mark.integration` — pixel-level: paints the X root via python-xlib `XFillRectangle`, asserts captured BGRA bytes. |
 | `tests/test_integration_wlr.py` | `@pytest.mark.wayland` — pixel-level via the `wayland_painter.py` kiosk client under headless `cage`. |
 | `tests/test_recording.py` | codec inference, ffmpeg argv/drawtext, click patterns, cursor stamping, subtitles, CLI parsing; a few `skipif(not X11)` recorder smoke tests that really invoke ffmpeg. |
+| `tests/test_macos_backend.py` | `@pytest.mark.no_display` — the points-vs-pixels snapping as a pure function, plus the copy path over a fake CoreGraphics/CoreFoundation pair. The only place `off_x`/`off_y` run, since CI Macs are 1x. Runs everywhere. |
+| `tests/test_wlr_backend.py` | `@pytest.mark.no_display` — `WlrBackend.refresh()` over hand-built output state; covers the mode-change and output-reselection paths the single-output `cage` session cannot. Skipped without pywayland. |
 | `tests/conftest.py` | `paint_root` (X11) and `paint_wayland` fixtures; autouse `require_some_display` (no-op on Windows/macOS); `_x11_available()` / `_wayland_available()` helpers; `FASTGRAB_TEST_BACKEND` env selects the backend under test. |
 | `tests/_run_pytest_clean_exit.py` | runs pytest then `os._exit` — bypasses pywayland cffi finalizers segfaulting at interpreter shutdown. Use it instead of bare `pytest` in containers. |
 
@@ -194,8 +196,13 @@ Test-writing rules:
   write into `tmp_path`.
 - Overlay/subtitle logic is pure numpy / pure string building — test it
   without a display.
-- Keep `test_screenshot.py` platform-agnostic; it is the only suite that
-  runs on the Windows and macOS runners.
+- Keep `test_screenshot.py` platform-agnostic. It is not the only suite
+  on the Windows and macOS runners any more — `test_macos_backend.py`
+  and `test_wlr_backend.py` collect there too, because they drive fakes
+  rather than a real display. Anything that reaches a display server
+  needs a marker (`integration`, `wayland`) or a `skipif`, and anything
+  importing a platform-only module needs a `collect_ignore` entry in
+  `tests/conftest.py`, since marker filters do not prevent imports.
 
 ## 7. CI (`.github/workflows/test.yml`)
 
@@ -305,7 +312,10 @@ containers — say so.
 - [ ] BGRA contract preserved; buffer reuse preserved.
 - [ ] `docker compose run --rm test` passes; wayland suite run if backends
       touched.
-- [ ] `test_screenshot.py` still platform-agnostic.
+- [ ] `test_screenshot.py` still platform-agnostic; anything else that
+      collects on the Windows/macOS runners still runs without a display.
+- [ ] Coordinates crossing the backend interface are still device pixels
+      (see `backends/base.py`).
 - [ ] README and `backends/__init__.py` docstring updated for user-visible
       changes; `poetry.lock` regenerated if `pyproject.toml` deps changed.
 - [ ] No host-only assumptions (fonts, display numbers, paths) baked in;

--- a/fastgrab/backends/base.py
+++ b/fastgrab/backends/base.py
@@ -5,6 +5,21 @@ buffer with a region of the screen, in BGRA byte order on
 little-endian Linux x86_64. The high-level
 :class:`fastgrab.screenshot.Screenshot` wrapper owns the buffer and
 calls into the backend.
+
+**Coordinates are device pixels, everywhere.** Every size and offset
+crossing this interface — what :meth:`BaseBackend.resolution` reports,
+the ``(x, y)`` given to :meth:`BaseBackend.screenshot`, and the ``bbox``
+accepted by :meth:`fastgrab.screenshot.Screenshot.capture` — counts
+physical pixels in the backing store, never logical/scaled units. On a
+2x Retina panel an 1800x1169-point desktop reports and captures
+3600x2338.
+
+A backend whose platform speaks logical coordinates (macOS points,
+Wayland's logical surface size, the portal's ScreenCast source) must
+convert at its own boundary rather than leaking those units upward.
+Callers that mix the two — sizing a GUI window in points from a capture
+measured in pixels, say — get a silently wrong region rather than an
+error, so the conversion belongs in one place.
 """
 from abc import ABC, abstractmethod
 
@@ -12,7 +27,10 @@ from abc import ABC, abstractmethod
 class BaseBackend(ABC):
     @abstractmethod
     def resolution(self):
-        """Return ``(width, height)`` of the primary screen/output."""
+        """Return ``(width, height)`` of the primary screen/output.
+
+        In device pixels — see the module docstring.
+        """
 
     @abstractmethod
     def bytes_per_pixel(self):
@@ -32,7 +50,13 @@ class BaseBackend(ABC):
     def screenshot(self, x, y, img):
         """Fill ``img`` with the region starting at ``(x, y)``.
 
+        ``x`` and ``y`` are device pixels — see the module docstring.
         ``img`` is a pre-allocated ``(H, W, 4)`` uint8 numpy ndarray
         whose shape implicitly carries the requested capture size. The
         backend must write the whole buffer in BGRA byte order.
+
+        :class:`fastgrab.screenshot.Screenshot` validates the region
+        before calling, but this method is public and reachable
+        directly, so a backend should refuse a region it cannot honour
+        rather than silently capturing a different one.
         """

--- a/fastgrab/backends/base.py
+++ b/fastgrab/backends/base.py
@@ -27,9 +27,11 @@ promise the code keeps:
 * ``x11`` and ``macos`` honour it.
 * ``wlr`` honours it for full-output capture. Sub-region capture takes
   the region in *logical* coordinates (a ``wlr-screencopy`` protocol
-  requirement), which matches device pixels only at scale 1; the
-  backend refuses a sub-region request on a scaled output rather than
-  returning the wrong one. See issue #38.
+  requirement), which matches device pixels only on an output that is
+  both unscaled and untransformed — wlroots applies the transform
+  before the scale, so a rotation transposes the frame even at scale 1.
+  The backend refuses a sub-region request on any other output rather
+  than returning the wrong one. See issue #38.
 * ``windows`` reports and captures in whatever DPI context the host
   process happens to have. Windows virtualizes screen metrics for
   DPI-unaware threads and ``BitBlt`` takes logical units, and neither

--- a/fastgrab/backends/base.py
+++ b/fastgrab/backends/base.py
@@ -6,13 +6,12 @@ little-endian Linux x86_64. The high-level
 :class:`fastgrab.screenshot.Screenshot` wrapper owns the buffer and
 calls into the backend.
 
-**Coordinates are device pixels, everywhere.** Every size and offset
-crossing this interface — what :meth:`BaseBackend.resolution` reports,
-the ``(x, y)`` given to :meth:`BaseBackend.screenshot`, and the ``bbox``
-accepted by :meth:`fastgrab.screenshot.Screenshot.capture` — counts
-physical pixels in the backing store, never logical/scaled units. On a
-2x Retina panel an 1800x1169-point desktop reports and captures
-3600x2338.
+**Coordinates are device pixels.** Every size and offset crossing this
+interface — what :meth:`BaseBackend.resolution` reports, the ``(x, y)``
+given to :meth:`BaseBackend.screenshot`, and the ``bbox`` accepted by
+:meth:`fastgrab.screenshot.Screenshot.capture` — counts physical pixels
+in the backing store, never logical/scaled units. On a 2x Retina panel
+an 1800x1169-point desktop reports and captures 3600x2338.
 
 A backend whose platform speaks logical coordinates (macOS points,
 Wayland's logical surface size, the portal's ScreenCast source) must
@@ -20,6 +19,24 @@ convert at its own boundary rather than leaking those units upward.
 Callers that mix the two — sizing a GUI window in points from a capture
 measured in pixels, say — get a silently wrong region rather than an
 error, so the conversion belongs in one place.
+
+That is the contract new backends are held to, but not every shipped
+backend honours it yet. Known gaps, so this docstring is not read as a
+promise the code keeps:
+
+* ``x11`` and ``macos`` honour it.
+* ``wlr`` honours it for full-output capture. Sub-region capture takes
+  the region in *logical* coordinates (a ``wlr-screencopy`` protocol
+  requirement), which matches device pixels only at scale 1; the
+  backend refuses a sub-region request on a scaled output rather than
+  returning the wrong one. See issue #38.
+* ``windows`` reports and captures in whatever DPI context the host
+  process happens to have. Windows virtualizes screen metrics for
+  DPI-unaware threads and ``BitBlt`` takes logical units, and neither
+  the backend nor CPython's manifest establishes per-monitor awareness,
+  so at a display scale other than 100% these are not physical pixels.
+  See issue #39.
+* ``portal`` is a placeholder that raises ``NotImplementedError``.
 """
 from abc import ABC, abstractmethod
 

--- a/fastgrab/backends/base.py
+++ b/fastgrab/backends/base.py
@@ -18,6 +18,16 @@ class BaseBackend(ABC):
     def bytes_per_pixel(self):
         """Return the number of bytes per captured pixel (always 4 today)."""
 
+    def refresh(self):
+        """Re-resolve any display handle latched at construction time.
+
+        The default is a no-op, which is correct for backends that
+        resolve the display on every call. A backend that stores a
+        display id (macOS) overrides this so
+        :meth:`fastgrab.screenshot.Screenshot.refresh` can pick up a
+        change of main display.
+        """
+
     @abstractmethod
     def screenshot(self, x, y, img):
         """Fill ``img`` with the region starting at ``(x, y)``.

--- a/fastgrab/backends/macos.py
+++ b/fastgrab/backends/macos.py
@@ -32,12 +32,32 @@ from __future__ import annotations
 import ctypes
 import ctypes.util
 
+import numpy
+
 from .base import BaseBackend
 
 
 # CGImageAlphaInfo bits — keep in sync with CoreGraphics/CGImage.h
 _K_CG_BITMAP_BYTE_ORDER_MASK = 0x7000
 _K_CG_BITMAP_BYTE_ORDER_32_LITTLE = 2 << 12  # kCGBitmapByteOrder32Little
+
+
+def _ceil_div(numerator, denominator):
+    """Ceiling of ``numerator / denominator`` for non-negative integers."""
+    return -(-numerator // denominator)
+
+
+def _snap_axis(start, length, pixels, points):
+    """Snap one axis of a device-pixel span out to whole points.
+
+    ``pixels``/``points`` are that axis' extent in each unit. Returns
+    ``(pt_start, pt_length, offset)``: where to ask in points, how much
+    to ask for in points, and how far into the returned image the
+    requested span begins, in pixels.
+    """
+    pt_start = (start * points) // pixels
+    pt_end = _ceil_div((start + length) * points, pixels)
+    return pt_start, pt_end - pt_start, start - (pt_start * pixels) // points
 
 
 def _snap_rect_to_points(x, y, w, h, pixel_w, pixel_h, point_w, point_h):
@@ -51,15 +71,9 @@ def _snap_rect_to_points(x, y, w, h, pixel_w, pixel_h, point_w, point_h):
     for, in points, and the pixel offset of the requested region inside
     the returned image.
     """
-    pt_x0 = (x * point_w) // pixel_w
-    pt_y0 = (y * point_h) // pixel_h
-    pt_x1 = -((-(x + w) * point_w) // pixel_w)
-    pt_y1 = -((-(y + h) * point_h) // pixel_h)
-    return (
-        pt_x0, pt_y0, pt_x1 - pt_x0, pt_y1 - pt_y0,
-        x - (pt_x0 * pixel_w) // point_w,
-        y - (pt_y0 * pixel_h) // point_h,
-    )
+    pt_x, pt_w, off_x = _snap_axis(x, w, pixel_w, point_w)
+    pt_y, pt_h, off_y = _snap_axis(y, h, pixel_h, point_h)
+    return (pt_x, pt_y, pt_w, pt_h, off_x, off_y)
 
 
 def _load_frameworks():
@@ -341,20 +355,21 @@ class MacosBackend(BaseBackend):
                         .format(data_len, img_w, img_h, row_stride, expected)
                     )
 
-                dst_ptr = img.ctypes.data
-                base = src_ptr + off_y * row_stride + off_x * 4
-                if off_x == 0 and row_stride == w * 4:
-                    # Tightly packed — single memmove.
-                    ctypes.memmove(dst_ptr, base, w * h * 4)
-                else:
-                    # Stride padding (Apple often aligns to 16 bytes) or
-                    # a snapped left edge — copy row by row.
-                    for row in range(h):
-                        ctypes.memmove(
-                            dst_ptr + row * w * 4,
-                            base + row * row_stride,
-                            w * 4,
-                        )
+                # One strided view over the provider bytes, sliced to the
+                # requested region and copied in a single C-level pass.
+                # Row padding (Apple often aligns to 16 bytes) and a
+                # snapped left edge are both just slicing here; done with
+                # per-row memmoves they cost an interpreter round trip
+                # per row, and a snapped left edge is the common case for
+                # sub-rect captures on a 2x display.
+                src = numpy.frombuffer(
+                    (ctypes.c_ubyte * (row_stride * img_h)).from_address(
+                        src_ptr),
+                    dtype=numpy.uint8,
+                ).reshape(img_h, row_stride)
+                img[:] = src[
+                    off_y:off_y + h, off_x * 4:(off_x + w) * 4
+                ].reshape(h, w, 4)
             finally:
                 self._cf.CFRelease(cf_data)
         finally:

--- a/fastgrab/backends/macos.py
+++ b/fastgrab/backends/macos.py
@@ -211,6 +211,18 @@ class MacosBackend(BaseBackend):
         h, w, _ = img.shape
         pixel_w, pixel_h, point_w, point_h = self._display_geometry()
 
+        # Screenshot.check_bbox validates too, but this entry point is
+        # reachable directly. CoreGraphics clips a rect that reaches
+        # outside the display instead of refusing it, which would land
+        # as a confusing "CGImage too small" -- or, if the clipped image
+        # is still large enough, as silently shifted pixels.
+        if (w <= 0 or h <= 0 or x < 0 or y < 0
+                or x > pixel_w - w or y > pixel_h - h):
+            raise ValueError(
+                "region {}x{} at {},{} is outside the {}x{} display"
+                .format(w, h, x, y, pixel_w, pixel_h)
+            )
+
         # A full-screen grab predicts the returned size exactly; a snapped
         # sub-rect legitimately comes back larger than the region asked
         # for, so the two cases get different size checks below.

--- a/fastgrab/backends/macos.py
+++ b/fastgrab/backends/macos.py
@@ -9,6 +9,10 @@ V1 captures from the **main** display only (``CGMainDisplayID``).
 Multi-display capture via ``CGGetActiveDisplayList`` is a future
 ``Screenshot(display=N)`` extension.
 
+**Coordinates are device pixels**, matching X11 and wlr, and so are
+``bbox`` rectangles: a 2x panel with an 1800x1169-point desktop reports
+and captures 3600x2338.
+
 Byte order matches the rest of fastgrab: ``CGDisplayCreateImage``
 returns 32-bit-per-pixel little-endian BGRA on both Intel and Apple
 Silicon, so the captured numpy array is BGRA — same contract as X11
@@ -36,6 +40,28 @@ _K_CG_BITMAP_BYTE_ORDER_MASK = 0x7000
 _K_CG_BITMAP_BYTE_ORDER_32_LITTLE = 2 << 12  # kCGBitmapByteOrder32Little
 
 
+def _snap_rect_to_points(x, y, w, h, pixel_w, pixel_h, point_w, point_h):
+    """Map a device-pixel rect to the whole-point rect containing it.
+
+    ``CGDisplayCreateImageForRect`` takes points but returns pixels, and
+    rounds a fractional rect *outward* — 400.5 points yields 802 pixels,
+    not 801 — so round outward ourselves.
+
+    Returns ``(pt_x, pt_y, pt_w, pt_h, off_x, off_y)``: the rect to ask
+    for, in points, and the pixel offset of the requested region inside
+    the returned image.
+    """
+    pt_x0 = (x * point_w) // pixel_w
+    pt_y0 = (y * point_h) // pixel_h
+    pt_x1 = -((-(x + w) * point_w) // pixel_w)
+    pt_y1 = -((-(y + h) * point_h) // pixel_h)
+    return (
+        pt_x0, pt_y0, pt_x1 - pt_x0, pt_y1 - pt_y0,
+        x - (pt_x0 * pixel_w) // point_w,
+        y - (pt_y0 * pixel_h) // point_h,
+    )
+
+
 def _load_frameworks():
     cg_path = ctypes.util.find_library("CoreGraphics")
     cf_path = ctypes.util.find_library("CoreFoundation")
@@ -54,10 +80,19 @@ def _load_frameworks():
     cg.CGMainDisplayID.argtypes = []
     cg.CGMainDisplayID.restype = ctypes.c_uint32
 
-    cg.CGDisplayPixelsWide.argtypes = [ctypes.c_uint32]
-    cg.CGDisplayPixelsWide.restype = ctypes.c_size_t
-    cg.CGDisplayPixelsHigh.argtypes = [ctypes.c_uint32]
-    cg.CGDisplayPixelsHigh.restype = ctypes.c_size_t
+    cg.CGDisplayCopyDisplayMode.argtypes = [ctypes.c_uint32]
+    cg.CGDisplayCopyDisplayMode.restype = ctypes.c_void_p
+
+    cg.CGDisplayModeGetWidth.argtypes = [ctypes.c_void_p]
+    cg.CGDisplayModeGetWidth.restype = ctypes.c_size_t
+    cg.CGDisplayModeGetHeight.argtypes = [ctypes.c_void_p]
+    cg.CGDisplayModeGetHeight.restype = ctypes.c_size_t
+    cg.CGDisplayModeGetPixelWidth.argtypes = [ctypes.c_void_p]
+    cg.CGDisplayModeGetPixelWidth.restype = ctypes.c_size_t
+    cg.CGDisplayModeGetPixelHeight.argtypes = [ctypes.c_void_p]
+    cg.CGDisplayModeGetPixelHeight.restype = ctypes.c_size_t
+    cg.CGDisplayModeRelease.argtypes = [ctypes.c_void_p]
+    cg.CGDisplayModeRelease.restype = None
 
     class CGPoint(ctypes.Structure):
         _fields_ = [("x", ctypes.c_double), ("y", ctypes.c_double)]
@@ -116,24 +151,45 @@ class MacosBackend(BaseBackend):
 
     # -------- BaseBackend API --------
 
+    def _display_geometry(self):
+        """Return ``(pixel_w, pixel_h, point_w, point_h)``, read fresh
+        each call so a mode switch is picked up on the next capture.
+        """
+        mode = self._cg.CGDisplayCopyDisplayMode(self._display)
+        if not mode:
+            raise RuntimeError("CGDisplayCopyDisplayMode returned NULL")
+        try:
+            return (
+                int(self._cg.CGDisplayModeGetPixelWidth(mode)),
+                int(self._cg.CGDisplayModeGetPixelHeight(mode)),
+                int(self._cg.CGDisplayModeGetWidth(mode)),
+                int(self._cg.CGDisplayModeGetHeight(mode)),
+            )
+        finally:
+            # Core Foundation *copy* rule: we own the +1 reference.
+            self._cg.CGDisplayModeRelease(mode)
+
     def resolution(self):
-        w = self._cg.CGDisplayPixelsWide(self._display)
-        h = self._cg.CGDisplayPixelsHigh(self._display)
-        return (int(w), int(h))
+        pixel_w, pixel_h, _, _ = self._display_geometry()
+        return (pixel_w, pixel_h)
 
     def bytes_per_pixel(self):
         return 4
 
     def screenshot(self, x, y, img):
         h, w, _ = img.shape
-        full_w, full_h = self.resolution()
+        pixel_w, pixel_h, point_w, point_h = self._display_geometry()
 
-        if x == 0 and y == 0 and w == full_w and h == full_h:
+        if x == 0 and y == 0 and w == pixel_w and h == pixel_h:
             image = self._cg.CGDisplayCreateImage(self._display)
+            off_x = off_y = 0
         else:
+            pt_x, pt_y, pt_w, pt_h, off_x, off_y = _snap_rect_to_points(
+                x, y, w, h, pixel_w, pixel_h, point_w, point_h
+            )
             rect = self._CGRect(
-                origin=self._CGPoint(x=float(x), y=float(y)),
-                size=self._CGSize(width=float(w), height=float(h)),
+                origin=self._CGPoint(x=float(pt_x), y=float(pt_y)),
+                size=self._CGSize(width=float(pt_w), height=float(pt_h)),
             )
             image = self._cg.CGDisplayCreateImageForRect(self._display, rect)
         if not image:
@@ -164,10 +220,10 @@ class MacosBackend(BaseBackend):
             row_stride = self._cg.CGImageGetBytesPerRow(image)
             img_w = self._cg.CGImageGetWidth(image)
             img_h = self._cg.CGImageGetHeight(image)
-            if img_w != w or img_h != h:
+            if img_w < off_x + w or img_h < off_y + h:
                 raise RuntimeError(
-                    "CGImage size {}x{} does not match requested {}x{}; "
-                    "Retina scale-factor mismatch?".format(img_w, img_h, w, h)
+                    "CGImage {}x{} too small for a {}x{} region at "
+                    "offset {},{}".format(img_w, img_h, w, h, off_x, off_y)
                 )
 
             provider = self._cg.CGImageGetDataProvider(image)
@@ -180,16 +236,17 @@ class MacosBackend(BaseBackend):
                 if not src_ptr:
                     raise RuntimeError("CFDataGetBytePtr returned NULL")
                 dst_ptr = img.ctypes.data
-                if row_stride == w * 4:
+                base = src_ptr + off_y * row_stride + off_x * 4
+                if off_x == 0 and row_stride == w * 4:
                     # Tightly packed — single memmove.
-                    ctypes.memmove(dst_ptr, src_ptr, w * h * 4)
+                    ctypes.memmove(dst_ptr, base, w * h * 4)
                 else:
-                    # Stride padding (Apple often aligns to 16 bytes) —
-                    # copy row by row.
+                    # Stride padding (Apple often aligns to 16 bytes) or
+                    # a snapped left edge — copy row by row.
                     for row in range(h):
                         ctypes.memmove(
                             dst_ptr + row * w * 4,
-                            src_ptr + row * row_stride,
+                            base + row * row_stride,
                             w * 4,
                         )
             finally:

--- a/fastgrab/backends/macos.py
+++ b/fastgrab/backends/macos.py
@@ -116,6 +116,8 @@ def _load_frameworks():
     cg.CGImageGetBytesPerRow.restype = ctypes.c_size_t
     cg.CGImageGetBitsPerPixel.argtypes = [ctypes.c_void_p]
     cg.CGImageGetBitsPerPixel.restype = ctypes.c_size_t
+    cg.CGImageGetBitsPerComponent.argtypes = [ctypes.c_void_p]
+    cg.CGImageGetBitsPerComponent.restype = ctypes.c_size_t
     cg.CGImageGetBitmapInfo.argtypes = [ctypes.c_void_p]
     cg.CGImageGetBitmapInfo.restype = ctypes.c_uint32
     cg.CGImageGetDataProvider.argtypes = [ctypes.c_void_p]
@@ -151,15 +153,32 @@ class MacosBackend(BaseBackend):
 
     # -------- BaseBackend API --------
 
+    def refresh(self):
+        """Re-read which display is the main one.
+
+        ``CGMainDisplayID`` is resolved once at construction, so
+        unplugging a monitor or promoting a different one to main is
+        otherwise never noticed.
+        """
+        display = self._cg.CGMainDisplayID()
+        if display == 0:
+            raise RuntimeError("CGMainDisplayID returned 0; no main display?")
+        self._display = display
+
     def _display_geometry(self):
-        """Return ``(pixel_w, pixel_h, point_w, point_h)``, read fresh
-        each call so a mode switch is picked up on the next capture.
+        """Return ``(pixel_w, pixel_h, point_w, point_h)``.
+
+        Read fresh on every call, so this backend itself never holds a
+        stale mode. Note that the size the *public* API reports is
+        cached by :attr:`fastgrab.screenshot.Screenshot.screensize`; a
+        mode switch is picked up on the next capture only after calling
+        :meth:`fastgrab.screenshot.Screenshot.refresh`.
         """
         mode = self._cg.CGDisplayCopyDisplayMode(self._display)
         if not mode:
             raise RuntimeError("CGDisplayCopyDisplayMode returned NULL")
         try:
-            return (
+            geometry = (
                 int(self._cg.CGDisplayModeGetPixelWidth(mode)),
                 int(self._cg.CGDisplayModeGetPixelHeight(mode)),
                 int(self._cg.CGDisplayModeGetWidth(mode)),
@@ -168,6 +187,18 @@ class MacosBackend(BaseBackend):
         finally:
             # Core Foundation *copy* rule: we own the +1 reference.
             self._cg.CGDisplayModeRelease(mode)
+
+        if not all(geometry):
+            # A mirrored, virtual or sleeping display can report zero for
+            # a dimension. Left alone it divides by zero inside the
+            # snapping arithmetic, which says nothing about the display.
+            raise RuntimeError(
+                "display mode reports a zero dimension: pixels={}x{} "
+                "points={}x{} — the display may be asleep, mirrored or "
+                "virtual.".format(*geometry)
+            )
+
+        return geometry
 
     def resolution(self):
         pixel_w, pixel_h, _, _ = self._display_geometry()
@@ -180,7 +211,11 @@ class MacosBackend(BaseBackend):
         h, w, _ = img.shape
         pixel_w, pixel_h, point_w, point_h = self._display_geometry()
 
-        if x == 0 and y == 0 and w == pixel_w and h == pixel_h:
+        # A full-screen grab predicts the returned size exactly; a snapped
+        # sub-rect legitimately comes back larger than the region asked
+        # for, so the two cases get different size checks below.
+        whole_screen = x == 0 and y == 0 and w == pixel_w and h == pixel_h
+        if whole_screen:
             image = self._cg.CGDisplayCreateImage(self._display)
             off_x = off_y = 0
         else:
@@ -206,6 +241,19 @@ class MacosBackend(BaseBackend):
                     "expected 32-bpp image from CGDisplayCreateImage, got "
                     "{} bpp".format(bpp)
                 )
+            bits_per_component = self._cg.CGImageGetBitsPerComponent(image)
+            if bits_per_component != 8:
+                # 32 bpp is not enough on its own: a wide-gamut/EDR
+                # surface is 32-bit 10-10-10-2, which passes the bpp and
+                # byte-order checks and copies the right number of bytes
+                # while scrambling every channel value.
+                raise RuntimeError(
+                    "expected 8 bits per component from "
+                    "CGDisplayCreateImage, got {} — this looks like a "
+                    "wide-gamut/EDR surface, which fastgrab cannot yet "
+                    "convert to BGRA8. Please open an issue."
+                    .format(bits_per_component)
+                )
             info = self._cg.CGImageGetBitmapInfo(image)
             if (info & _K_CG_BITMAP_BYTE_ORDER_MASK) != _K_CG_BITMAP_BYTE_ORDER_32_LITTLE:
                 # We've only ever observed 32-little (BGRA) on shipping
@@ -220,7 +268,23 @@ class MacosBackend(BaseBackend):
             row_stride = self._cg.CGImageGetBytesPerRow(image)
             img_w = self._cg.CGImageGetWidth(image)
             img_h = self._cg.CGImageGetHeight(image)
-            if img_w < off_x + w or img_h < off_y + h:
+            if whole_screen:
+                # The display mode said exactly how big this would be, so
+                # anything else means the mode changed under us or this
+                # display reports a scale factor we do not understand.
+                # Accepting a larger image here would silently return its
+                # top-left corner.
+                if img_w != pixel_w or img_h != pixel_h:
+                    raise RuntimeError(
+                        "CGImage {}x{} does not match the display mode's "
+                        "{}x{} pixel size — the mode changed mid-capture, "
+                        "or this display reports a scale factor fastgrab "
+                        "does not understand. Please open an issue."
+                        .format(img_w, img_h, pixel_w, pixel_h)
+                    )
+            elif img_w < off_x + w or img_h < off_y + h:
+                # Snapping to whole points legitimately over-provisions,
+                # so only a *short* image is wrong here.
                 raise RuntimeError(
                     "CGImage {}x{} too small for a {}x{} region at "
                     "offset {},{}".format(img_w, img_h, w, h, off_x, off_y)
@@ -235,6 +299,25 @@ class MacosBackend(BaseBackend):
                 src_ptr = self._cf.CFDataGetBytePtr(cf_data)
                 if not src_ptr:
                     raise RuntimeError("CFDataGetBytePtr returned NULL")
+
+                # The copy trusts that the provider bytes start at this
+                # image's own top-left with the stride reported above. A
+                # CGImage backed by a *parent* bitmap breaks that: the
+                # stride is the parent's and the data begins at the
+                # parent's origin. Bounding the read against the actual
+                # length turns that into a loud error instead of rows
+                # copied from the wrong place.
+                data_len = self._cf.CFDataGetLength(cf_data)
+                needed = (off_y + h - 1) * row_stride + (off_x + w) * 4
+                if data_len < needed:
+                    raise RuntimeError(
+                        "CFData holds {} bytes, but a {}x{} region at "
+                        "offset {},{} with a {}-byte row stride needs {} "
+                        "— the CGImage may be a view into a larger parent "
+                        "bitmap. Please open an issue.".format(
+                            data_len, w, h, off_x, off_y, row_stride, needed)
+                    )
+
                 dst_ptr = img.ctypes.data
                 base = src_ptr + off_y * row_stride + off_x * 4
                 if off_x == 0 and row_stride == w * 4:

--- a/fastgrab/backends/macos.py
+++ b/fastgrab/backends/macos.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import ctypes
 import ctypes.util
+import numbers
 
 import numpy
 
@@ -225,6 +226,21 @@ class MacosBackend(BaseBackend):
         h, w, _ = img.shape
         pixel_w, pixel_h, point_w, point_h = self._display_geometry()
 
+        # Reject a non-integer origin before the comparisons below, not
+        # after: every one of them is False for nan, so nan would sail
+        # through the region guard and reach the snapping arithmetic,
+        # and a float origin produces a float source address that
+        # ctypes.memmove rejects. Screenshot.capture normalizes integral
+        # floats to int before this point, so nothing valid is refused.
+        for _name, _value in (("x", x), ("y", y)):
+            if isinstance(_value, bool) or not isinstance(
+                    _value, numbers.Integral):
+                raise ValueError(
+                    "{} must be an integer number of device pixels, got "
+                    "{!r}".format(_name, _value)
+                )
+        x, y = int(x), int(y)
+
         # Screenshot.check_bbox validates too, but this entry point is
         # reachable directly. CoreGraphics clips a rect that reaches
         # outside the display instead of refusing it, which would land
@@ -343,9 +359,17 @@ class MacosBackend(BaseBackend):
                 # so an over-allocated provider is not forbidden. Failing
                 # closed is the right trade here — the alternative is
                 # returning someone else's pixels.
+                if row_stride < img_w * 4:
+                    raise RuntimeError(
+                        "unsupported row stride: CGImage reports {} bytes "
+                        "per row for a {}-pixel-wide 32-bit image, which "
+                        "needs at least {}. Please open an issue."
+                        .format(row_stride, img_w, img_w * 4)
+                    )
+
                 data_len = self._cf.CFDataGetLength(cf_data)
                 expected = row_stride * img_h
-                if row_stride < img_w * 4 or data_len != expected:
+                if data_len != expected:
                     raise RuntimeError(
                         "unsupported provider extent: CFData holds {} bytes "
                         "for a {}x{} image with a {}-byte row stride, where "

--- a/fastgrab/backends/macos.py
+++ b/fastgrab/backends/macos.py
@@ -316,18 +316,29 @@ class MacosBackend(BaseBackend):
                 # image's own top-left with the stride reported above. A
                 # CGImage backed by a *parent* bitmap breaks that: the
                 # stride is the parent's and the data begins at the
-                # parent's origin. Bounding the read against the actual
-                # length turns that into a loud error instead of rows
-                # copied from the wrong place.
+                # parent's origin.
+                #
+                # Requiring the provider to hold exactly this image's rows
+                # catches the common shape of that layout, and bounds the
+                # read either way. It cannot *prove* the logical origin —
+                # only a provider of a different extent is detectable —
+                # and it is a deliberate fastgrab invariant rather than a
+                # documented CoreGraphics one: CGImageCreate takes the
+                # provider and the extent as separate inputs and only
+                # requires the buffer to be at least bytesPerRow*height,
+                # so an over-allocated provider is not forbidden. Failing
+                # closed is the right trade here — the alternative is
+                # returning someone else's pixels.
                 data_len = self._cf.CFDataGetLength(cf_data)
-                needed = (off_y + h - 1) * row_stride + (off_x + w) * 4
-                if data_len < needed:
+                expected = row_stride * img_h
+                if row_stride < img_w * 4 or data_len != expected:
                     raise RuntimeError(
-                        "CFData holds {} bytes, but a {}x{} region at "
-                        "offset {},{} with a {}-byte row stride needs {} "
-                        "— the CGImage may be a view into a larger parent "
-                        "bitmap. Please open an issue.".format(
-                            data_len, w, h, off_x, off_y, row_stride, needed)
+                        "unsupported provider extent: CFData holds {} bytes "
+                        "for a {}x{} image with a {}-byte row stride, where "
+                        "{} was expected. fastgrab reads the provider bytes "
+                        "directly and cannot locate the image inside a "
+                        "buffer of another size. Please open an issue."
+                        .format(data_len, img_w, img_h, row_stride, expected)
                     )
 
                 dst_ptr = img.ctypes.data

--- a/fastgrab/backends/wlr.py
+++ b/fastgrab/backends/wlr.py
@@ -204,6 +204,23 @@ class WlrBackend(BaseBackend):
         if x == 0 and y == 0 and w == full_w and h == full_h:
             frame = self._screencopy.capture_output(0, self._output.proxy)
         else:
+            # capture_output_region takes the region in *logical*
+            # coordinates -- the protocol XML says so explicitly -- while
+            # a fastgrab bbox is device pixels. The two coincide only at
+            # scale 1. On a scale-2 output a 20x10 pixel request would be
+            # sent as 20x10 logical, the compositor would return a 40x20
+            # frame, and the origin would be displaced as well. Refuse
+            # rather than hand back the wrong region; full-output capture
+            # goes through capture_output above and is unaffected.
+            if self._output.scale != 1:
+                raise NotImplementedError(
+                    "sub-region capture is not supported on output {!r} at "
+                    "scale {}: wlr-screencopy takes the region in logical "
+                    "coordinates while fastgrab bboxes are device pixels, "
+                    "so they agree only at scale 1. Capture the full "
+                    "output and slice the returned array instead."
+                    .format(self._output.name, self._output.scale)
+                )
             frame = self._screencopy.capture_output_region(
                 0, self._output.proxy, x, y, w, h
             )

--- a/fastgrab/backends/wlr.py
+++ b/fastgrab/backends/wlr.py
@@ -266,6 +266,27 @@ class WlrBackend(BaseBackend):
             frame.destroy()
             raise RuntimeError("wlr-screencopy frame failed before buffer info")
 
+        # The up-front guard cannot catch every non-identity mapping:
+        # wl_output.scale is an *integer* event and wlroots reports
+        # ceil() of the real scale, so an output at 0.75 announces scale
+        # 1 and looks like identity. The compositor then returns a
+        # smaller frame, and `img[:] = arr` would broadcast it over the
+        # destination instead of failing -- a 1x1 frame silently filling
+        # a 2x2 request. Checking what actually came back catches that,
+        # and any other cause, before a single byte is copied.
+        if state.w != w or state.h != h:
+            frame.destroy()
+            raise NotImplementedError(
+                "compositor returned a {}x{} frame for a {}x{} request on "
+                "output {!r} (reported scale {}, transform {}): the region "
+                "is interpreted in logical coordinates, and wl_output.scale "
+                "is an integer, so a fractionally scaled output reports 1 "
+                "and cannot be detected up front. Capture the full output "
+                "and slice the returned array instead."
+                .format(state.w, state.h, w, h, self._output.name,
+                        self._output.scale, self._output.transform)
+            )
+
         wl_buffer, mm = self._ensure_buffer(state.fmt, state.w, state.h, state.stride)
 
         frame.copy(wl_buffer)

--- a/fastgrab/backends/wlr.py
+++ b/fastgrab/backends/wlr.py
@@ -173,6 +173,25 @@ class WlrBackend(BaseBackend):
 
     # -------- BaseBackend API --------
 
+    def refresh(self):
+        """Re-read output geometry and re-select the output.
+
+        Unlike x11 and windows, this backend does not query the
+        compositor per call: ``resolution()`` returns ``wl_output`` mode
+        fields latched from events at connect time, so a mode change is
+        invisible until the display is dispatched again. Two round trips
+        let pending ``mode``/``name``/``done`` events settle, matching
+        what ``_connect_singleton`` does.
+
+        Mode changes and a different ``FASTGRAB_OUTPUT`` choice among the
+        already-bound outputs are picked up. An output that has since
+        been unplugged is *not*: that needs registry ``global_remove``
+        tracking, which this backend does not do.
+        """
+        self._display.roundtrip()
+        self._display.roundtrip()
+        self._output = self._select_output()
+
     def resolution(self):
         return (self._output.mode_w, self._output.mode_h)
 

--- a/fastgrab/backends/wlr.py
+++ b/fastgrab/backends/wlr.py
@@ -33,7 +33,8 @@ _FRAME_VERSION = 3
 
 class _OutputState:
     """Mutable accumulator for a single ``wl_output``'s geometry events."""
-    __slots__ = ("proxy", "name", "mode_w", "mode_h", "scale", "done")
+    __slots__ = ("proxy", "name", "mode_w", "mode_h", "scale", "transform",
+                 "done")
 
     def __init__(self, proxy):
         self.proxy = proxy
@@ -41,6 +42,9 @@ class _OutputState:
         self.mode_w = 0
         self.mode_h = 0
         self.scale = 1
+        # WL_OUTPUT_TRANSFORM_NORMAL; anything else rotates or flips the
+        # logical coordinate space relative to the backing store.
+        self.transform = 0
         self.done = False
 
 
@@ -109,6 +113,10 @@ class WlrBackend(BaseBackend):
                 proxy.dispatcher["scale"] = lambda p, factor, s=state: (
                     WlrBackend._on_output_scale(s, factor)
                 )
+                proxy.dispatcher["geometry"] = lambda p, gx, gy, pw, ph, \
+                    subpixel, make, model, transform, s=state: (
+                    WlrBackend._on_output_geometry(s, transform)
+                )
                 proxy.dispatcher["done"] = lambda p, s=state: (
                     WlrBackend._on_output_done(s)
                 )
@@ -153,6 +161,10 @@ class WlrBackend(BaseBackend):
     @staticmethod
     def _on_output_scale(state, factor):
         state.scale = factor
+
+    @staticmethod
+    def _on_output_geometry(state, transform):
+        state.transform = transform
 
     @staticmethod
     def _on_output_done(state):
@@ -206,20 +218,24 @@ class WlrBackend(BaseBackend):
         else:
             # capture_output_region takes the region in *logical*
             # coordinates -- the protocol XML says so explicitly -- while
-            # a fastgrab bbox is device pixels. The two coincide only at
-            # scale 1. On a scale-2 output a 20x10 pixel request would be
-            # sent as 20x10 logical, the compositor would return a 40x20
-            # frame, and the origin would be displaced as well. Refuse
-            # rather than hand back the wrong region; full-output capture
-            # goes through capture_output above and is unaffected.
-            if self._output.scale != 1:
+            # a fastgrab bbox is device pixels. The identity mapping
+            # between them needs BOTH an unscaled and an untransformed
+            # output: wlroots applies the output transform before the
+            # scale, so a 90-degree rotation transposes the frame even at
+            # scale 1 (a 20x10 request comes back 10x20), and a scale of
+            # 2 doubles it. Refuse anything but the identity case rather
+            # than hand back the wrong region; full-output capture goes
+            # through capture_output above and is unaffected.
+            if self._output.scale != 1 or self._output.transform != 0:
                 raise NotImplementedError(
-                    "sub-region capture is not supported on output {!r} at "
-                    "scale {}: wlr-screencopy takes the region in logical "
-                    "coordinates while fastgrab bboxes are device pixels, "
-                    "so they agree only at scale 1. Capture the full "
+                    "sub-region capture is not supported on output {!r} "
+                    "(scale {}, transform {}): wlr-screencopy takes the "
+                    "region in logical coordinates while fastgrab bboxes "
+                    "are device pixels, and the two agree only on an "
+                    "unscaled, untransformed output. Capture the full "
                     "output and slice the returned array instead."
-                    .format(self._output.name, self._output.scale)
+                    .format(self._output.name, self._output.scale,
+                            self._output.transform)
                 )
             frame = self._screencopy.capture_output_region(
                 0, self._output.proxy, x, y, w, h

--- a/fastgrab/linux_x11/screenshot.c
+++ b/fastgrab/linux_x11/screenshot.c
@@ -15,6 +15,7 @@
 #define FG_OK            0
 #define FG_ERR_DISPLAY  -1
 #define FG_ERR_GETIMAGE -2
+#define FG_ERR_BOUNDS   -3
 
 static const char *fg_strerror(int code)
 {
@@ -25,6 +26,9 @@ static const char *fg_strerror(int code)
     case FG_ERR_GETIMAGE:
         return "XGetImage failed: region outside the screen, or the X "
                "server refused the request";
+    case FG_ERR_BOUNDS:
+        return "requested region is outside the screen, or has a "
+               "non-positive width or height";
     default:
         return "unknown X11 error";
     }
@@ -53,10 +57,31 @@ static int screenshot(const int origin_x,
 {
     XImage *img;
     Display *display;
+    Screen *screen;
+
+    /* Bounds are checked here rather than left to the server: a region
+     * that reaches outside the root window is a BadMatch, and the NULL
+     * check below cannot catch it. X protocol errors are delivered
+     * asynchronously to Xlib's *default error handler*, which prints a
+     * diagnostic and calls exit() -- the interpreter dies with no
+     * exception and no traceback. The public API validates too, but
+     * this entry point is reachable directly, and
+     * examples/low_level_api_screenshot.py promotes exactly that. */
+    if (width <= 0 || height <= 0)
+        return FG_ERR_BOUNDS;
 
     display = XOpenDisplay(NULL);
     if (display == NULL)
         return FG_ERR_DISPLAY;
+
+    screen = ScreenOfDisplay(display, DefaultScreen(display));
+    /* Written as subtractions so a large origin cannot overflow int. */
+    if (origin_x < 0 || origin_y < 0 ||
+        origin_x > screen->width - width ||
+        origin_y > screen->height - height) {
+        XCloseDisplay(display);
+        return FG_ERR_BOUNDS;
+    }
 
     img = XGetImage(display,
                     RootWindow(display, DefaultScreen(display)),

--- a/fastgrab/linux_x11/screenshot.c
+++ b/fastgrab/linux_x11/screenshot.c
@@ -54,7 +54,12 @@ static int screen_resolution(int *resolution)
     display = XOpenDisplay(NULL);
     if (display == NULL)
         return FG_ERR_DISPLAY;
-    screen = ScreenOfDisplay(display, 0);
+    /* DefaultScreen(), not 0: capture and its bounds check both use
+     * RootWindow(display, DefaultScreen(display)), and on a DISPLAY of
+     * the form :N.1 those are different screens. Reporting one screen's
+     * size while capturing another makes the high-level bbox check
+     * disagree with what the server will actually allow. */
+    screen = ScreenOfDisplay(display, DefaultScreen(display));
     resolution[0] = screen->width;
     resolution[1] = screen->height;
     XCloseDisplay(display);

--- a/fastgrab/linux_x11/screenshot.c
+++ b/fastgrab/linux_x11/screenshot.c
@@ -1,3 +1,4 @@
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -16,6 +17,9 @@
 #define FG_ERR_DISPLAY  -1
 #define FG_ERR_GETIMAGE -2
 #define FG_ERR_BOUNDS   -3
+#define FG_ERR_DEPTH    -4
+#define FG_ERR_CAPACITY -5
+#define FG_ERR_STRIDE   -6
 
 static const char *fg_strerror(int code)
 {
@@ -29,6 +33,14 @@ static const char *fg_strerror(int code)
     case FG_ERR_BOUNDS:
         return "requested region is outside the screen, or has a "
                "non-positive width or height";
+    case FG_ERR_DEPTH:
+        return "X server returned a non 32-bit image; fastgrab needs a "
+               "32-bit ZPixmap visual to produce BGRA";
+    case FG_ERR_CAPACITY:
+        return "image buffer is too small for the requested region";
+    case FG_ERR_STRIDE:
+        return "X server returned a row stride narrower than the "
+               "requested width";
     default:
         return "unknown X11 error";
     }
@@ -53,7 +65,8 @@ static int screenshot(const int origin_x,
                       const int origin_y,
                       const int width,
                       const int height,
-                      uint8_t *data)
+                      uint8_t *data,
+                      const size_t capacity)
 {
     XImage *img;
     Display *display;
@@ -92,12 +105,44 @@ static int screenshot(const int origin_x,
         return FG_ERR_GETIMAGE;
     }
 
-    /* One memcpy straight out of the XImage: ZPixmap on a 32-bit visual
-     * is laid out B,G,R,A on little-endian hosts, which is the byte order
-     * the Python side promises. */
-    const size_t nbytes =
-        (size_t)width * height * img->bits_per_pixel / BITS_PER_BYTE;
-    memcpy(data, img->data, nbytes);
+    /* ZPixmap on a 32-bit visual is laid out B,G,R,A on little-endian
+     * hosts, which is the byte order the Python side promises. Anything
+     * else would be copied as the wrong number of bytes per pixel and
+     * handed back as if it were BGRA. */
+    if (img->bits_per_pixel != 32) {
+        XDestroyImage(img);
+        XCloseDisplay(display);
+        return FG_ERR_DEPTH;
+    }
+
+    const size_t row_bytes = (size_t)width * 4;
+    const size_t nbytes = row_bytes * (size_t)height;
+
+    /* Defence in depth: the caller's buffer was already checked against
+     * the requested shape, but the size actually copied is derived from
+     * what the server returned. */
+    if (nbytes > capacity) {
+        XDestroyImage(img);
+        XCloseDisplay(display);
+        return FG_ERR_CAPACITY;
+    }
+    if ((size_t)img->bytes_per_line < row_bytes) {
+        XDestroyImage(img);
+        XCloseDisplay(display);
+        return FG_ERR_STRIDE;
+    }
+
+    if ((size_t)img->bytes_per_line == row_bytes) {
+        memcpy(data, img->data, nbytes);
+    } else {
+        /* The server is free to pad rows; copying straight through would
+         * shear the image by the padding on every row. */
+        int row;
+        for (row = 0; row < height; row++)
+            memcpy(data + (size_t)row * row_bytes,
+                   img->data + (size_t)row * (size_t)img->bytes_per_line,
+                   row_bytes);
+    }
 
     XDestroyImage(img);
     XCloseDisplay(display);
@@ -159,22 +204,49 @@ static PyObject *linux_x11_screenshot(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "iiO", &x, &y, &_img))
         return NULL;
 
-    img = (PyArrayObject *)PyArray_FROM_OTF(_img, NPY_UINT8,
-                                            NPY_ARRAY_OUT_ARRAY);
-    if (img == NULL)
+    /* Reject rather than coerce. PyArray_FROM_OTF would happily build a
+     * temporary uint8 C-contiguous copy of a mismatched buffer, let the
+     * capture fill *that*, and then discard it -- the caller's array
+     * would come back untouched with no error raised. Propagating the
+     * result instead would need NPY_ARRAY_INOUT_ARRAY2 plus
+     * PyArray_ResolveWritebackIfCopy; for a buffer the caller allocates
+     * specifically to be filled, a strict contract is clearer. */
+    if (!PyArray_Check(_img)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "image buffer must be a numpy ndarray");
         return NULL;
+    }
+    img = (PyArrayObject *)_img;   /* borrowed; do not DECREF */
 
-    if (PyArray_NDIM(img) != 3) {
-        Py_DECREF(img);
+    if (PyArray_TYPE(img) != NPY_UINT8) {
+        PyErr_SetString(PyExc_ValueError,
+                        "image buffer must have dtype uint8");
+        return NULL;
+    }
+    if (!PyArray_ISCARRAY(img)) {
+        PyErr_SetString(PyExc_ValueError,
+                        "image buffer must be C-contiguous, aligned and "
+                        "writable");
+        return NULL;
+    }
+    if (PyArray_NDIM(img) != 3 || PyArray_SHAPE(img)[2] != 4) {
         PyErr_SetString(PyExc_ValueError,
                         "image buffer must be a (height, width, 4) array");
         return NULL;
     }
 
     shape = PyArray_SHAPE(img);
+    if (shape[0] <= 0 || shape[1] <= 0 ||
+        shape[0] > INT_MAX || shape[1] > INT_MAX) {
+        PyErr_SetString(PyExc_ValueError,
+                        "image buffer height and width must be positive "
+                        "and fit in a C int");
+        return NULL;
+    }
+
     rc = screenshot(x, y, (int)shape[1], (int)shape[0],
-                    (uint8_t *)PyArray_DATA(img));
-    Py_DECREF(img);
+                    (uint8_t *)PyArray_DATA(img),
+                    (size_t)PyArray_NBYTES(img));
 
     if (rc != FG_OK) {
         PyErr_SetString(PyExc_RuntimeError, fg_strerror(rc));

--- a/fastgrab/screenshot.py
+++ b/fastgrab/screenshot.py
@@ -53,13 +53,22 @@ class Screenshot(object):
         screen captures keep covering the old region and boxes in the
         newly available area are rejected as out of bounds.
 
-        Call this when the display setup changes. It drops the cached
-        size and the capture buffer, and asks the backend to re-resolve
-        whatever it latched onto at construction.
+        Call this when the display setup changes. It asks the backend to
+        re-resolve whatever it latched onto at construction, then drops
+        the cached size and the capture buffer.
+
+        What a backend can actually notice varies: x11 and windows query
+        the display on every call, so nothing is latched; macOS re-reads
+        which display is the main one; wlr re-reads output geometry and
+        re-selects its output, but does not track outputs disappearing.
+
+        The backend is asked first on purpose — if it raises, the cached
+        size and buffer are left intact rather than thrown away in
+        favour of nothing.
         """
+        self._backend.refresh()
         self._screensize = None
         self._img = None
-        self._backend.refresh()
 
     @staticmethod
     def _as_pixels(name, value, bbox):

--- a/fastgrab/screenshot.py
+++ b/fastgrab/screenshot.py
@@ -1,6 +1,8 @@
 """
 Module that implements the object for taking screenshots
 """
+import numbers
+
 import numpy
 
 from fastgrab.backends import _resolve_backend
@@ -39,17 +41,137 @@ class Screenshot(object):
         else:
             return self._screensize
 
+    @staticmethod
+    def _as_pixels(name, value, bbox):
+        """
+        Return ``value`` as a plain :class:`int` count of device pixels
+
+        Anything that is exactly a whole number is accepted: :class:`int`,
+        ``numpy.int64`` and friends, and integral floats such as ``7.0``
+        (Python 3 division produces those readily, and they were already
+        usable on the Windows backend).
+
+        Fractional values are rejected rather than rounded — there is no
+        honest choice between floor, round and ceil, and any of them
+        silently returns a region the caller did not ask for.
+
+        The return value is deliberately a plain ``int``: backends do
+        pointer arithmetic with these numbers, and a ``numpy`` integer
+        both propagates into ``ctypes`` calls that reject it and wraps
+        silently on overflow instead of growing.
+        """
+        if isinstance(value, bool):
+            # bool is an Integral, but a boolean pixel count is always a
+            # mistake — and False would quietly mean zero.
+            msg = (
+                'bbox {} must be a number of device pixels, got the '
+                'boolean {!r}.\n'
+                'bbox={}'
+            ).format(name, value, bbox)
+            raise ValueError(msg)
+
+        if isinstance(value, numbers.Integral):
+            return int(value)
+
+        if isinstance(value, numbers.Real):
+            # Compare against int(value) directly instead of going
+            # through float(): float() silently rounds a near-integral
+            # Fraction to a whole number, and raises OverflowError on a
+            # large one, which would escape as the wrong exception type.
+            # int() is exact for every Real, and != then compares
+            # exactly.
+            try:
+                as_int = int(value)
+            except (ValueError, OverflowError, TypeError):
+                # nan raises ValueError, inf raises OverflowError.
+                msg = (
+                    'bbox {} must be a finite number of device pixels, '
+                    'got {!r}.\n'
+                    'bbox={}'
+                ).format(name, value, bbox)
+                raise ValueError(msg)
+            if value != as_int:
+                msg = (
+                    'bbox {} must be a whole number of device pixels, got '
+                    '{!r} — there is no half pixel to capture. Round it '
+                    'yourself to say which pixel you mean.\n'
+                    'bbox={}'
+                ).format(name, value, bbox)
+                raise ValueError(msg)
+            return as_int
+
+        msg = (
+            'bbox {} must be a number of device pixels, got {!r} of type '
+            '{}.\n'
+            'bbox={}'
+        ).format(name, value, type(value).__name__, bbox)
+        raise ValueError(msg)
+
     def check_bbox(self, bbox):
         """
-        Raise an exception of the bounding box is outside the screen bounds
+        Validate a bounding box and return it normalized
+
+        Raises :class:`ValueError` if the box is malformed or reaches
+        outside the screen bounds. All four components are **device
+        pixels**: ``x`` and ``y`` must not be negative, ``width`` and
+        ``height`` must be positive, and each must be a whole number
+        (see :meth:`_as_pixels` for what counts as one).
+
+        Validating here keeps every backend from having to defend itself
+        against a malformed box, which they otherwise report as
+        confusing low-level errors — or, on X11, not at all: a negative
+        origin reaches ``XGetImage`` as a ``BadMatch`` that the default
+        Xlib error handler turns into an outright process exit.
+
+        :param bbox: (x0, y0, width, height) in device pixels.
+        :return: the same box as a tuple of four plain :class:`int`
+         values, safe to hand to a backend.
         """
-        x, y, w, h = bbox
+        try:
+            components = tuple(bbox)
+        except TypeError:
+            msg = (
+                'bbox must be a sequence of four values '
+                '(x, y, width, height), got {!r}.'
+            ).format(bbox)
+            raise ValueError(msg)
+
+        if len(components) != 4:
+            msg = (
+                'bbox must have exactly four components '
+                '(x, y, width, height), got {}.\n'
+                'bbox={}'
+            ).format(len(components), bbox)
+            raise ValueError(msg)
+
+        x, y, w, h = (
+            self._as_pixels(name, value, bbox)
+            for name, value in zip(('x', 'y', 'width', 'height'), components)
+        )
+
+        if x < 0 or y < 0:
+            msg = (
+                'bbox x and y must not be negative, got x={}, y={}.\n'
+                'bbox={}'
+            ).format(x, y, bbox)
+            raise ValueError(msg)
+
+        if w <= 0 or h <= 0:
+            msg = (
+                'bbox width and height must be positive, got width={}, '
+                'height={} — an empty region has nothing to capture.\n'
+                'bbox={}'
+            ).format(w, h, bbox)
+            raise ValueError(msg)
+
         if (x + w) > self.screensize[0] or (y + h) > self.screensize[1]:
             msg = (
                 'bbox is outside the screen boarders.\n'
                 'bbox={} screen size={}'
             ).format(bbox, self.screensize)
             raise ValueError(msg)
+
+        return (x, y, w, h)
 
     def capture(self, bbox: tuple=None) -> numpy.ndarray:
         """
@@ -74,7 +196,12 @@ class Screenshot(object):
             plt.show()
 
         :param bbox: the upper left corner of the screenshot and the width
-         and heigh (x0, y0, width, height).
+         and heigh (x0, y0, width, height), in **device pixels**. Each
+         component must be a whole number — ``int``, a numpy integer, or
+         an integral float such as ``7.0``, which is coerced. A
+         fractional value such as ``7.5`` raises :class:`ValueError`;
+         round it yourself to say which pixel you mean. ``x``/``y`` must
+         not be negative and ``width``/``height`` must be positive.
         :return: The image as a numpy array of shape (height, width, 4) in
          BGRA byte order.
         """
@@ -83,10 +210,11 @@ class Screenshot(object):
         if bbox is None:
             width, height = self.screensize
             bbox = (0, 0, width, height)
-        else:
-            _, _, width, height = bbox
 
-        self.check_bbox(bbox)
+        # Normalized to plain ints — backends do pointer arithmetic with
+        # the origin, so a numpy integer or an integral float must not
+        # reach them unconverted.
+        x, y, width, height = self.check_bbox(bbox)
 
         bpp = self._backend.bytes_per_pixel()
 
@@ -102,6 +230,6 @@ class Screenshot(object):
                     (height, width, bpp), 'uint8'
                 )
 
-        self._backend.screenshot(bbox[0], bbox[1], self._img)
+        self._backend.screenshot(x, y, self._img)
 
         return self._img

--- a/fastgrab/screenshot.py
+++ b/fastgrab/screenshot.py
@@ -41,6 +41,26 @@ class Screenshot(object):
         else:
             return self._screensize
 
+    def refresh(self):
+        """
+        Forget cached display geometry so the next capture re-reads it
+
+        :attr:`screensize` is cached after its first read — capture
+        loops ask for it on every frame, and re-querying the display
+        each time would put a round trip in the hot path. The cost is
+        that a resolution change, a monitor being plugged in, or a
+        different display becoming the main one goes unnoticed: full
+        screen captures keep covering the old region and boxes in the
+        newly available area are rejected as out of bounds.
+
+        Call this when the display setup changes. It drops the cached
+        size and the capture buffer, and asks the backend to re-resolve
+        whatever it latched onto at construction.
+        """
+        self._screensize = None
+        self._img = None
+        self._backend.refresh()
+
     @staticmethod
     def _as_pixels(name, value, bbox):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,4 +73,5 @@ build-backend = "poetry.core.masonry.api"
 markers = [
     "integration: pixel-level tests that mutate X server state (need DISPLAY + xsetroot)",
     "wayland: pixel-level tests that exercise the Wayland (wlr-screencopy) backend (need WAYLAND_DISPLAY + a wlroots compositor like cage)",
+    "no_display: tests that drive fakes and need no display server, so the require_some_display gate lets them run on a headless box",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,17 +46,37 @@ def _wayland_available() -> bool:
     return os.path.exists(os.path.join(rd, wd))
 
 
-@pytest.fixture(scope="session", autouse=True)
-def require_some_display():
+_SOME_DISPLAY = None
+
+
+def _some_display_available() -> bool:
+    # Cached: the gate is consulted once per test, and _x11_available()
+    # shells out to xdpyinfo.
+    global _SOME_DISPLAY
+    if _SOME_DISPLAY is None:
+        _SOME_DISPLAY = _x11_available() or _wayland_available()
+    return _SOME_DISPLAY
+
+
+@pytest.fixture(autouse=True)
+def require_some_display(request):
+    """Skip tests that need a display when there is not one.
+
+    Per-test rather than per-session, and skippable with the
+    ``no_display`` marker: suites that drive fakes (the macOS and wlr
+    backend unit tests) need no display at all, and a session-wide skip
+    took them down with everything else — losing exactly the coverage a
+    contributor gets when running pytest on a headless box, which is
+    also the only place ``off_x``/``off_y`` are ever exercised.
+    """
     # On Windows/macOS the system always has a desktop available to capture;
     # the display-server gate is a Linux-only concept.
     if sys.platform != "linux":
         return
-    if not (_x11_available() or _wayland_available()):
-        pytest.skip(
-            "no usable display server (need DISPLAY or WAYLAND_DISPLAY)",
-            allow_module_level=True,
-        )
+    if request.node.get_closest_marker("no_display"):
+        return
+    if not _some_display_available():
+        pytest.skip("no usable display server (need DISPLAY or WAYLAND_DISPLAY)")
 
 
 @pytest.fixture

--- a/tests/test_macos_backend.py
+++ b/tests/test_macos_backend.py
@@ -259,6 +259,29 @@ def test_oversized_full_screen_image_is_rejected():
         _capture(backend, 0, 0, 20, 16)
 
 
+def test_oversized_cfdata_is_rejected():
+    """The parent-bitmap layout makes the provider *larger*, not shorter.
+
+    A short-buffer check alone never fires for it: a cropped CGImage
+    sharing its parent's storage reports the parent's stride and hands
+    back the parent's bytes, so every row is read from the wrong origin
+    while all the size checks pass.
+    """
+    backend, _, cf = _backend()
+    real = cf.CFDataGetLength
+    cf.CFDataGetLength = lambda data: real(data) + 4096
+    with pytest.raises(RuntimeError, match="unsupported provider extent"):
+        _capture(backend, 7, 5, 11, 9)
+
+
+def test_stride_narrower_than_a_row_is_rejected():
+    backend, cg, _ = _backend()
+    real = cg.CGImageGetBytesPerRow
+    cg.CGImageGetBytesPerRow = lambda image: real(image) - 4
+    with pytest.raises(RuntimeError, match="unsupported provider extent"):
+        _capture(backend, 7, 5, 11, 9)
+
+
 def test_short_cfdata_is_rejected_rather_than_over_read():
     """The provider bytes must cover what the stride arithmetic reads.
 

--- a/tests/test_macos_backend.py
+++ b/tests/test_macos_backend.py
@@ -278,11 +278,36 @@ def test_oversized_cfdata_is_rejected():
 
 
 def test_stride_narrower_than_a_row_is_rejected():
+    """Reported separately from the extent, so the message cannot lie.
+
+    Sharing one error with the extent check let it claim the data length
+    matched expectations in the very case where it did.
+    """
     backend, cg, _ = _backend()
     real = cg.CGImageGetBytesPerRow
     cg.CGImageGetBytesPerRow = lambda image: real(image) - 4
-    with pytest.raises(RuntimeError, match="unsupported provider extent"):
+    with pytest.raises(RuntimeError, match="unsupported row stride"):
         _capture(backend, 7, 5, 11, 9)
+
+
+@pytest.mark.parametrize("x, y", [
+    (float("nan"), 0),
+    (0, float("nan")),
+    (7.0, 0),
+    (0, 7.5),
+    (True, 0),
+])
+def test_non_integer_origin_is_refused_at_the_backend(x, y):
+    """nan defeats the region guard: every comparison against it is False.
+
+    A float origin also produces a float source address that
+    ctypes.memmove rejects. Screenshot.capture() normalizes integral
+    floats before this point, so only direct callers see this.
+    """
+    backend, _, _ = _backend()
+    img = numpy.zeros((6, 8, 4), numpy.uint8)
+    with pytest.raises(ValueError, match="must be an integer"):
+        backend.screenshot(x, y, img)
 
 
 def test_short_cfdata_is_rejected_rather_than_over_read():

--- a/tests/test_macos_backend.py
+++ b/tests/test_macos_backend.py
@@ -292,6 +292,25 @@ def test_degenerate_display_mode_raises_a_clear_error(dimension):
         backend.screenshot(1, 1, numpy.zeros((2, 2, 4), numpy.uint8))
 
 
+@pytest.mark.parametrize("x, y, w, h", [
+    (-1, 0, 8, 6),
+    (0, -1, 8, 6),
+    (36, 0, 8, 6),       # runs past the right edge
+    (0, 26, 8, 6),       # runs past the bottom edge
+    (0, 0, 0, 6),        # empty region
+])
+def test_out_of_range_region_is_refused_at_the_backend(x, y, w, h):
+    """The backend is reachable directly, not only via check_bbox.
+
+    CoreGraphics clips such a rect rather than refusing it, so without
+    this the caller gets a confusing "too small" error or, worse,
+    silently shifted pixels.
+    """
+    backend, _, _ = _backend()
+    with pytest.raises(ValueError, match="outside the"):
+        backend.screenshot(x, y, numpy.zeros((h, w, 4), numpy.uint8))
+
+
 def test_refresh_re_reads_the_main_display():
     """The display id is latched in __init__; refresh() must re-resolve."""
     backend, cg, _ = _backend()

--- a/tests/test_macos_backend.py
+++ b/tests/test_macos_backend.py
@@ -1,0 +1,178 @@
+"""Tests for the macOS backend: the points-vs-pixels split on Retina.
+
+The rect arithmetic is a pure function, tested directly. The copy path
+memmoves out of a CFData pointer, so it gets a fake ctypes layer — the
+only place ``off_x``/``off_y`` ever run, since CI Macs are 1x.
+"""
+import ctypes
+from types import SimpleNamespace
+
+import numpy
+import pytest
+
+from fastgrab.backends.macos import (
+    MacosBackend,
+    _snap_rect_to_points,
+    _K_CG_BITMAP_BYTE_ORDER_32_LITTLE,
+)
+
+# a 40x30-pixel backing store; RETINA drives it from a 20x15-point desktop
+RETINA = dict(pixel_w=40, pixel_h=30, point_w=20, point_h=15)
+FLAT = dict(pixel_w=40, pixel_h=30, point_w=40, point_h=30)
+
+
+@pytest.mark.parametrize("rect, expected", [
+    # (x, y, w, h) -> (pt_x, pt_y, pt_w, pt_h, off_x, off_y)
+    ((0, 0, 8, 6), (0, 0, 4, 3, 0, 0)),        # aligned to the scale
+    ((2, 4, 10, 8), (1, 2, 5, 4, 0, 0)),       # even offset and size
+    ((7, 5, 11, 9), (3, 2, 6, 5, 1, 1)),       # odd -> snaps out, offset 1,1
+    ((1, 1, 1, 1), (0, 0, 1, 1, 1, 1)),        # single pixel inside a point
+    ((39, 29, 1, 1), (19, 14, 1, 1, 1, 1)),    # bottom-right corner
+])
+def test_rect_snaps_outward_to_whole_points(rect, expected):
+    assert _snap_rect_to_points(*rect, **RETINA) == expected
+
+
+@pytest.mark.parametrize("rect", [(0, 0, 8, 6), (7, 5, 11, 9), (39, 29, 1, 1)])
+def test_rect_is_unchanged_without_scaling(rect):
+    x, y, w, h = rect
+    assert _snap_rect_to_points(*rect, **FLAT) == (x, y, w, h, 0, 0)
+
+
+class _FakeCoreGraphics:
+    """The slice of CoreGraphics the backend calls, over a numpy screen."""
+
+    def __init__(self, screen, point_w, point_h, row_pad=0):
+        self.screen = screen
+        self.pixel_h, self.pixel_w = screen.shape[:2]
+        self.point_w, self.point_h = point_w, point_h
+        self.row_pad = row_pad
+        self._meta = {}
+        self._buffers = {}
+
+    def CGDisplayCopyDisplayMode(self, display):
+        return 1
+
+    def CGDisplayModeRelease(self, mode):
+        pass
+
+    def CGDisplayModeGetWidth(self, mode):
+        return self.point_w
+
+    def CGDisplayModeGetHeight(self, mode):
+        return self.point_h
+
+    def CGDisplayModeGetPixelWidth(self, mode):
+        return self.pixel_w
+
+    def CGDisplayModeGetPixelHeight(self, mode):
+        return self.pixel_h
+
+    def _image(self, x, y, w, h):
+        stride = w * 4 + self.row_pad
+        buf = (ctypes.c_ubyte * (stride * h))()
+        for index, row in enumerate(self.screen[y:y + h, x:x + w]):
+            ctypes.memmove(ctypes.byref(buf, index * stride), row.tobytes(),
+                           w * 4)
+        token = len(self._meta) + 1
+        self._meta[token] = (w, h, stride)
+        self._buffers[token] = buf
+        return token
+
+    def CGDisplayCreateImage(self, display):
+        return self._image(0, 0, self.pixel_w, self.pixel_h)
+
+    def CGDisplayCreateImageForRect(self, display, rect):
+        asked = (rect.origin.x, rect.origin.y,
+                 rect.size.width, rect.size.height)
+        # the real API rounds a fractional rect outward, which is the
+        # trap the backend exists to avoid -- so refuse to model it
+        assert all(v == int(v) for v in asked), \
+            "rect must be whole points, got %r" % (asked,)
+        scale_x = self.pixel_w / self.point_w
+        scale_y = self.pixel_h / self.point_h
+        return self._image(int(asked[0] * scale_x), int(asked[1] * scale_y),
+                           int(asked[2] * scale_x), int(asked[3] * scale_y))
+
+    def CGImageGetWidth(self, image):
+        return self._meta[image][0]
+
+    def CGImageGetHeight(self, image):
+        return self._meta[image][1]
+
+    def CGImageGetBytesPerRow(self, image):
+        return self._meta[image][2]
+
+    def CGImageGetBitsPerPixel(self, image):
+        return 32
+
+    def CGImageGetBitmapInfo(self, image):
+        return _K_CG_BITMAP_BYTE_ORDER_32_LITTLE
+
+    def CGImageGetDataProvider(self, image):
+        return image
+
+    def CGDataProviderCopyData(self, provider):
+        return provider
+
+    def CGImageRelease(self, image):
+        pass
+
+    def CFDataGetBytePtr(self, data):
+        return ctypes.addressof(self._buffers[data])
+
+    def CFRelease(self, data):
+        pass
+
+
+def _backend(point_w=20, point_h=15, row_pad=0):
+    """A MacosBackend wired to fakes, bypassing framework loading."""
+    screen = numpy.random.default_rng(0).integers(
+        0, 256, (30, 40, 4), dtype=numpy.uint8)
+    cg = _FakeCoreGraphics(screen, point_w, point_h, row_pad)
+    backend = object.__new__(MacosBackend)
+    backend._cg = backend._cf = cg
+    backend._display = 1
+    # the backend builds these with kwargs; the fake only reads attributes
+    backend._CGPoint = backend._CGSize = backend._CGRect = SimpleNamespace
+    return backend, cg
+
+
+def _capture(backend, x, y, w, h):
+    img = numpy.zeros((h, w, 4), numpy.uint8)
+    backend.screenshot(x, y, img)
+    return img
+
+
+def test_resolution_reports_pixels_not_points():
+    """The original bug: resolution() returned points, capture got pixels."""
+    backend, _ = _backend()
+    assert backend.resolution() == (40, 30)
+
+
+@pytest.mark.parametrize("row_pad", [0, 12])
+@pytest.mark.parametrize("x, y, w, h", [
+    (0, 0, 40, 30),      # full screen, via CGDisplayCreateImage
+    (0, 0, 8, 6),
+    (7, 5, 11, 9),       # odd offset and size -> sub-rectangle copy
+    (39, 29, 1, 1),
+])
+def test_capture_matches_the_backing_store(x, y, w, h, row_pad):
+    backend, cg = _backend(row_pad=row_pad)
+    img = _capture(backend, x, y, w, h)
+    assert img.shape == (h, w, 4)
+    assert numpy.array_equal(img, cg.screen[y:y + h, x:x + w])
+
+
+def test_capture_matches_without_scaling():
+    backend, cg = _backend(point_w=40, point_h=30)
+    assert numpy.array_equal(_capture(backend, 7, 5, 11, 9),
+                             cg.screen[5:14, 7:18])
+
+
+def test_undersized_image_is_rejected_rather_than_over_read():
+    backend, cg = _backend()
+    real = cg.CGImageGetWidth
+    cg.CGImageGetWidth = lambda image: real(image) - 4
+    with pytest.raises(RuntimeError, match="too small"):
+        _capture(backend, 7, 5, 11, 9)

--- a/tests/test_macos_backend.py
+++ b/tests/test_macos_backend.py
@@ -24,6 +24,9 @@ from fastgrab.backends.macos import (
     _K_CG_BITMAP_BYTE_ORDER_32_LITTLE,
 )
 
+# Everything here runs against fakes — no display server, on any platform.
+pytestmark = pytest.mark.no_display
+
 # a 40x30-pixel backing store; RETINA drives it from a 20x15-point desktop
 RETINA = dict(pixel_w=40, pixel_h=30, point_w=20, point_h=15)
 FLAT = dict(pixel_w=40, pixel_h=30, point_w=40, point_h=30)

--- a/tests/test_macos_backend.py
+++ b/tests/test_macos_backend.py
@@ -3,6 +3,14 @@
 The rect arithmetic is a pure function, tested directly. The copy path
 memmoves out of a CFData pointer, so it gets a fake ctypes layer — the
 only place ``off_x``/``off_y`` ever run, since CI Macs are 1x.
+
+The fakes deliberately model CoreGraphics where it is *unforgiving*:
+``_FakeCoreGraphics._image`` refuses an out-of-bounds rect rather than
+letting numpy clip it into a zero-padded image, the display mode can
+under-report its pixel size so an oversized capture can be exercised,
+and CoreGraphics and CoreFoundation are separate objects so a symbol
+called on the wrong framework handle fails here the way it would on a
+real machine.
 """
 import ctypes
 from types import SimpleNamespace
@@ -33,7 +41,12 @@ def test_rect_snaps_outward_to_whole_points(rect, expected):
     assert _snap_rect_to_points(*rect, **RETINA) == expected
 
 
-@pytest.mark.parametrize("rect", [(0, 0, 8, 6), (7, 5, 11, 9), (39, 29, 1, 1)])
+@pytest.mark.parametrize("rect", [
+    (0, 0, 8, 6),
+    (7, 5, 11, 9),
+    (1, 1, 1, 1),        # degenerate single pixel, the 1x twin of the above
+    (39, 29, 1, 1),
+])
 def test_rect_is_unchanged_without_scaling(rect):
     x, y, w, h = rect
     assert _snap_rect_to_points(*rect, **FLAT) == (x, y, w, h, 0, 0)
@@ -42,13 +55,24 @@ def test_rect_is_unchanged_without_scaling(rect):
 class _FakeCoreGraphics:
     """The slice of CoreGraphics the backend calls, over a numpy screen."""
 
-    def __init__(self, screen, point_w, point_h, row_pad=0):
+    def __init__(self, screen, point_w, point_h, row_pad=0,
+                 mode_pixel_w=None, mode_pixel_h=None):
         self.screen = screen
         self.pixel_h, self.pixel_w = screen.shape[:2]
         self.point_w, self.point_h = point_w, point_h
         self.row_pad = row_pad
+        # What CGDisplayModeGetPixel{Width,Height} claim. Defaults to the
+        # real backing store; a test can make the mode under-report to
+        # model a display whose mode dict omits the HiDPI pixel fields.
+        self.mode_pixel_w = self.pixel_w if mode_pixel_w is None else mode_pixel_w
+        self.mode_pixel_h = self.pixel_h if mode_pixel_h is None else mode_pixel_h
+        self.bits_per_component = 8
+        self.main_display = 1
         self._meta = {}
         self._buffers = {}
+
+    def CGMainDisplayID(self):
+        return self.main_display
 
     def CGDisplayCopyDisplayMode(self, display):
         return 1
@@ -63,12 +87,20 @@ class _FakeCoreGraphics:
         return self.point_h
 
     def CGDisplayModeGetPixelWidth(self, mode):
-        return self.pixel_w
+        return self.mode_pixel_w
 
     def CGDisplayModeGetPixelHeight(self, mode):
-        return self.pixel_h
+        return self.mode_pixel_h
 
     def _image(self, x, y, w, h):
+        if x < 0 or y < 0 or x + w > self.pixel_w or y + h > self.pixel_h:
+            # numpy would clip this to a short slice and leave the rest of
+            # the buffer zeroed while the metadata still claimed the full
+            # size — a silently "valid" image no real API would return.
+            raise AssertionError(
+                "rect %r falls outside the %dx%d screen; real CoreGraphics "
+                "clips to the display bounds and returns a smaller image"
+                % ((x, y, w, h), self.pixel_w, self.pixel_h))
         stride = w * 4 + self.row_pad
         buf = (ctypes.c_ubyte * (stride * h))()
         for index, row in enumerate(self.screen[y:y + h, x:x + w]):
@@ -80,6 +112,8 @@ class _FakeCoreGraphics:
         return token
 
     def CGDisplayCreateImage(self, display):
+        # Always the real backing store, which is what makes an
+        # under-reporting mode produce an oversized image.
         return self._image(0, 0, self.pixel_w, self.pixel_h)
 
     def CGDisplayCreateImageForRect(self, display, rect):
@@ -106,6 +140,9 @@ class _FakeCoreGraphics:
     def CGImageGetBitsPerPixel(self, image):
         return 32
 
+    def CGImageGetBitsPerComponent(self, image):
+        return self.bits_per_component
+
     def CGImageGetBitmapInfo(self, image):
         return _K_CG_BITMAP_BYTE_ORDER_32_LITTLE
 
@@ -118,24 +155,44 @@ class _FakeCoreGraphics:
     def CGImageRelease(self, image):
         pass
 
+
+class _FakeCoreFoundation:
+    """The CoreFoundation symbols, deliberately a separate object.
+
+    Collapsing this into the CoreGraphics fake would hide a symbol
+    looked up on the wrong framework handle — which on a real machine
+    either raises or resolves with no argtypes set and truncates a
+    pointer to 32 bits.
+    """
+
+    def __init__(self, cg):
+        self._cg = cg
+
     def CFDataGetBytePtr(self, data):
-        return ctypes.addressof(self._buffers[data])
+        return ctypes.addressof(self._cg._buffers[data])
+
+    def CFDataGetLength(self, data):
+        return len(self._cg._buffers[data])
 
     def CFRelease(self, data):
         pass
 
 
-def _backend(point_w=20, point_h=15, row_pad=0):
+def _backend(point_w=20, point_h=15, row_pad=0,
+             mode_pixel_w=None, mode_pixel_h=None):
     """A MacosBackend wired to fakes, bypassing framework loading."""
     screen = numpy.random.default_rng(0).integers(
         0, 256, (30, 40, 4), dtype=numpy.uint8)
-    cg = _FakeCoreGraphics(screen, point_w, point_h, row_pad)
+    cg = _FakeCoreGraphics(screen, point_w, point_h, row_pad,
+                           mode_pixel_w, mode_pixel_h)
+    cf = _FakeCoreFoundation(cg)
     backend = object.__new__(MacosBackend)
-    backend._cg = backend._cf = cg
+    backend._cg = cg
+    backend._cf = cf
     backend._display = 1
     # the backend builds these with kwargs; the fake only reads attributes
     backend._CGPoint = backend._CGSize = backend._CGRect = SimpleNamespace
-    return backend, cg
+    return backend, cg, cf
 
 
 def _capture(backend, x, y, w, h):
@@ -146,7 +203,7 @@ def _capture(backend, x, y, w, h):
 
 def test_resolution_reports_pixels_not_points():
     """The original bug: resolution() returned points, capture got pixels."""
-    backend, _ = _backend()
+    backend, _, _ = _backend()
     assert backend.resolution() == (40, 30)
 
 
@@ -155,24 +212,104 @@ def test_resolution_reports_pixels_not_points():
     (0, 0, 40, 30),      # full screen, via CGDisplayCreateImage
     (0, 0, 8, 6),
     (7, 5, 11, 9),       # odd offset and size -> sub-rectangle copy
+    (8, 5, 8, 9),        # off_x == 0 but off_y == 1: the off_y-only path
     (39, 29, 1, 1),
 ])
 def test_capture_matches_the_backing_store(x, y, w, h, row_pad):
-    backend, cg = _backend(row_pad=row_pad)
+    backend, cg, _ = _backend(row_pad=row_pad)
     img = _capture(backend, x, y, w, h)
     assert img.shape == (h, w, 4)
     assert numpy.array_equal(img, cg.screen[y:y + h, x:x + w])
 
 
 def test_capture_matches_without_scaling():
-    backend, cg = _backend(point_w=40, point_h=30)
+    backend, cg, _ = _backend(point_w=40, point_h=30)
     assert numpy.array_equal(_capture(backend, 7, 5, 11, 9),
                              cg.screen[5:14, 7:18])
 
 
 def test_undersized_image_is_rejected_rather_than_over_read():
-    backend, cg = _backend()
+    backend, cg, _ = _backend()
     real = cg.CGImageGetWidth
     cg.CGImageGetWidth = lambda image: real(image) - 4
     with pytest.raises(RuntimeError, match="too small"):
         _capture(backend, 7, 5, 11, 9)
+
+
+def test_undersized_image_height_is_rejected_rather_than_over_read():
+    """The height half of the guard; only the width half was covered."""
+    backend, cg, _ = _backend()
+    real = cg.CGImageGetHeight
+    cg.CGImageGetHeight = lambda image: real(image) - 4
+    with pytest.raises(RuntimeError, match="too small"):
+        _capture(backend, 7, 5, 11, 9)
+
+
+def test_oversized_full_screen_image_is_rejected():
+    """A mode that under-reports must not yield a silent top-left crop.
+
+    Models a virtual/Sidecar-style display whose mode dict omits the
+    HiDPI pixel fields, so the mode claims 20x16 while the capture comes
+    back as the real 40x30 backing store. A lower-bound size check
+    passes that happily and returns the top-left corner.
+    """
+    backend, _, _ = _backend(mode_pixel_w=20, mode_pixel_h=16)
+    assert backend.resolution() == (20, 16)
+    with pytest.raises(RuntimeError, match="does not match"):
+        _capture(backend, 0, 0, 20, 16)
+
+
+def test_short_cfdata_is_rejected_rather_than_over_read():
+    """The provider bytes must cover what the stride arithmetic reads.
+
+    A CGImage that CoreGraphics backs with a parent bitmap reports the
+    parent's stride while its data starts at the parent's origin; the
+    size checks all pass and every row is copied from the wrong place.
+    """
+    backend, _, cf = _backend()
+    real = cf.CFDataGetLength
+    cf.CFDataGetLength = lambda data: real(data) - 1
+    with pytest.raises(RuntimeError, match="CFData"):
+        _capture(backend, 7, 5, 11, 9)
+
+
+def test_non_8_bit_components_are_rejected():
+    """A 32-bpp 10-10-10-2 surface passes every other check."""
+    backend, cg, _ = _backend()
+    cg.bits_per_component = 10
+    with pytest.raises(RuntimeError, match="bits per component"):
+        _capture(backend, 0, 0, 8, 6)
+
+
+@pytest.mark.parametrize("dimension", [
+    "mode_pixel_w", "mode_pixel_h", "point_w", "point_h",
+])
+def test_degenerate_display_mode_raises_a_clear_error(dimension):
+    """A zero dimension must not surface as a bare ZeroDivisionError."""
+    backend, cg, _ = _backend()
+    setattr(cg, dimension, 0)
+    with pytest.raises(RuntimeError, match="display mode"):
+        backend.screenshot(1, 1, numpy.zeros((2, 2, 4), numpy.uint8))
+
+
+def test_refresh_re_reads_the_main_display():
+    """The display id is latched in __init__; refresh() must re-resolve."""
+    backend, cg, _ = _backend()
+    assert backend._display == 1
+    cg.main_display = 7
+    backend.refresh()
+    assert backend._display == 7
+
+
+def test_refresh_rejects_a_vanished_main_display():
+    backend, cg, _ = _backend()
+    cg.main_display = 0
+    with pytest.raises(RuntimeError, match="no main display"):
+        backend.refresh()
+
+
+def test_out_of_bounds_rect_is_not_silently_zero_padded():
+    """Guards the fake itself: numpy slicing used to clip these away."""
+    backend, cg, _ = _backend()
+    with pytest.raises(AssertionError, match="outside the"):
+        cg._image(35, 28, 10, 10)

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -6,6 +6,8 @@ without touching any platform-specific internals. The four
 ``_linux_x11``-direct tests live in ``tests/test_x11_lowlevel.py``
 and are skipped on non-Linux.
 """
+import fractions
+
 import numpy
 import pytest
 
@@ -50,6 +52,205 @@ def test_check_bbox_rejects_out_of_bounds_height():
     w, h = grab.screensize
     with pytest.raises(ValueError):
         grab.check_bbox((0, 0, w, h + 1))
+
+
+class _SpyBackend:
+    """Minimal backend that records what ``capture()`` forwards to it."""
+
+    def __init__(self, size=(200, 100)):
+        self._size = size
+        self.calls = []
+
+    def resolution(self):
+        return self._size
+
+    def bytes_per_pixel(self):
+        return 4
+
+    def screenshot(self, x, y, img):
+        self.calls.append((x, y))
+
+
+def _spying_screenshot():
+    """A Screenshot whose backend records calls instead of capturing."""
+    grab = screenshot.Screenshot()
+    grab._backend = _SpyBackend()
+    grab._screensize = None
+    return grab
+
+
+@pytest.mark.parametrize('bbox', [
+    (0.5, 0, 10, 10),
+    (0, 0.5, 10, 10),
+    (0, 0, 10.5, 10),
+    (0, 0, 10, 10.5),
+])
+def test_check_bbox_rejects_fractional_components(bbox):
+    """Half a pixel cannot be captured, and rounding it would lie.
+
+    Integral floats are fine (see the normalization test); only a real
+    fractional part is refused, because floor/round/ceil would each
+    silently return a different region than the caller asked for.
+    """
+    grab = screenshot.Screenshot()
+    with pytest.raises(ValueError, match='whole number'):
+        grab.check_bbox(bbox)
+
+
+@pytest.mark.parametrize('value', [float('nan'), float('inf'), float('-inf')])
+def test_check_bbox_rejects_non_finite_components(value):
+    grab = screenshot.Screenshot()
+    with pytest.raises(ValueError, match='finite'):
+        grab.check_bbox((value, 0, 10, 10))
+
+
+def test_check_bbox_rejects_near_integral_fraction():
+    """Exact reals must be compared exactly, not through float().
+
+    ``float()`` rounds this Fraction to exactly 1.0, which would let a
+    fractional value through as pixel 1.
+    """
+    grab = screenshot.Screenshot()
+    almost_one = fractions.Fraction(2 ** 54 + 1, 2 ** 54)
+    assert float(almost_one) == 1.0  # the trap being guarded against
+    with pytest.raises(ValueError, match='whole number'):
+        grab.check_bbox((almost_one, 0, 10, 10))
+
+
+def test_check_bbox_accepts_integral_fraction():
+    grab = screenshot.Screenshot()
+    normalized = grab.check_bbox((fractions.Fraction(8, 2), 0, 10, 10))
+    assert normalized == (4, 0, 10, 10)
+    assert type(normalized[0]) is int
+
+
+def test_check_bbox_reports_oversized_real_as_value_error():
+    """A huge exact value must not leak OverflowError from float()."""
+    grab = screenshot.Screenshot()
+    with pytest.raises(ValueError):
+        grab.check_bbox((fractions.Fraction(10 ** 400), 0, 10, 10))
+
+
+@pytest.mark.parametrize('bbox', [
+    ('0', 0, 10, 10),
+    (None, 0, 10, 10),
+    (0, 0, [10], 10),
+])
+def test_check_bbox_rejects_non_numeric_components(bbox):
+    grab = screenshot.Screenshot()
+    with pytest.raises(ValueError, match='must be a number'):
+        grab.check_bbox(bbox)
+
+
+@pytest.mark.parametrize('bbox', [
+    (True, 0, 10, 10),
+    (0, 0, 10, False),
+])
+def test_check_bbox_rejects_booleans(bbox):
+    """bool is a numbers.Integral, but a boolean pixel count is a mistake."""
+    grab = screenshot.Screenshot()
+    with pytest.raises(ValueError, match='boolean'):
+        grab.check_bbox(bbox)
+
+
+@pytest.mark.parametrize('bbox', [(-1, 0, 10, 10), (0, -1, 10, 10)])
+def test_check_bbox_rejects_negative_origin(bbox):
+    grab = screenshot.Screenshot()
+    with pytest.raises(ValueError, match='must not be negative'):
+        grab.check_bbox(bbox)
+
+
+@pytest.mark.parametrize('bbox', [
+    (0, 0, 0, 10),
+    (0, 0, 10, 0),
+    (0, 0, -1, 10),
+    (0, 0, 10, -1),
+])
+def test_check_bbox_rejects_non_positive_size(bbox):
+    """An empty region has nothing to capture and reaches every backend."""
+    grab = screenshot.Screenshot()
+    with pytest.raises(ValueError, match='must be positive'):
+        grab.check_bbox(bbox)
+
+
+@pytest.mark.parametrize('bbox', [(0, 0, 10), (0, 0, 10, 10, 10), ()])
+def test_check_bbox_rejects_wrong_component_count(bbox):
+    grab = screenshot.Screenshot()
+    with pytest.raises(ValueError, match='exactly four components'):
+        grab.check_bbox(bbox)
+
+
+def test_check_bbox_normalizes_to_plain_ints():
+    """Accepted values come back as plain ints, whatever went in.
+
+    Backends do pointer arithmetic with the origin: a numpy integer
+    propagates into ctypes calls that reject it, and numpy arithmetic
+    wraps on overflow instead of growing.
+    """
+    grab = screenshot.Screenshot()
+    normalized = grab.check_bbox((numpy.int64(4), 6.0, numpy.int32(10), 8))
+    assert normalized == (4, 6, 10, 8)
+    assert all(type(value) is int for value in normalized)
+
+
+def test_check_bbox_rejects_numpy_overflowing_bbox():
+    """numpy ints wrap on overflow; the bounds check must still catch it."""
+    grab = screenshot.Screenshot()
+    huge = numpy.int64(numpy.iinfo(numpy.int64).max)
+    with pytest.raises(ValueError):
+        grab.check_bbox((huge, 0, huge, 10))
+
+
+def test_capture_accepts_integral_float_bbox():
+    """``w / 2`` is a float in Python 3 and must keep working."""
+    grab = screenshot.Screenshot()
+    img = grab.capture(bbox=(0.0, 0.0, 10.0, 8.0))
+    assert img.shape == (8, 10, 4)
+
+
+def test_capture_rejects_fractional_bbox_origin():
+    grab = screenshot.Screenshot()
+    with pytest.raises(ValueError):
+        grab.capture(bbox=(0.5, 0, 10, 10))
+
+
+def test_capture_rejects_negative_bbox_origin():
+    """Regression: a negative origin must not reach the backend.
+
+    The bounds check only ever tested the far edge, so a negative origin
+    reached the platform capture call — on X11 that is a BadMatch which
+    the default Xlib error handler turns into an outright process exit.
+    """
+    grab = screenshot.Screenshot()
+    with pytest.raises(ValueError):
+        grab.capture(bbox=(-1, -1, 10, 10))
+
+
+def test_capture_forwards_plain_ints_to_the_backend():
+    """Regression: the backend must never receive a numpy int or a float.
+
+    Validating without normalizing left this path broken — the macOS
+    backend derives a memory address from the origin, and ctypes
+    rejects a numpy.int64 one exactly as it rejected a float.
+    """
+    grab = _spying_screenshot()
+    grab.capture(bbox=(numpy.int64(10), 4.0, 20, 8))
+    (x, y), = grab._backend.calls
+    assert (x, y) == (10, 4)
+    assert type(x) is int and type(y) is int
+
+
+@pytest.mark.parametrize('bbox', [
+    (0, 0, 10, 0),
+    (-1, 0, 10, 10),
+    (0.5, 0, 10, 10),
+    (True, 0, 10, 10),
+])
+def test_invalid_bbox_never_reaches_the_backend(bbox):
+    grab = _spying_screenshot()
+    with pytest.raises(ValueError):
+        grab.capture(bbox=bbox)
+    assert grab._backend.calls == []
 
 
 def test_capture_full_screen_shape_and_dtype():

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -58,14 +58,18 @@ class _SpyBackend:
     """Minimal backend that records what ``capture()`` forwards to it."""
 
     def __init__(self, size=(200, 100)):
-        self._size = size
+        self.size = size
         self.calls = []
+        self.refreshed = 0
 
     def resolution(self):
-        return self._size
+        return self.size
 
     def bytes_per_pixel(self):
         return 4
+
+    def refresh(self):
+        self.refreshed += 1
 
     def screenshot(self, x, y, img):
         self.calls.append((x, y))
@@ -251,6 +255,40 @@ def test_invalid_bbox_never_reaches_the_backend(bbox):
     with pytest.raises(ValueError):
         grab.capture(bbox=bbox)
     assert grab._backend.calls == []
+
+
+def test_refresh_picks_up_a_new_resolution():
+    """The cache is deliberate; refresh() is how a mode switch lands.
+
+    Without it a full-screen capture keeps covering the old region and
+    boxes in the newly available area are rejected as out of bounds.
+    """
+    grab = _spying_screenshot()
+    assert grab.screensize == (200, 100)
+
+    grab._backend.size = (300, 150)
+    assert grab.screensize == (200, 100)  # still cached, by design
+    with pytest.raises(ValueError):
+        grab.check_bbox((0, 0, 300, 150))
+
+    grab.refresh()
+    assert grab.screensize == (300, 150)
+    assert grab.check_bbox((0, 0, 300, 150)) == (0, 0, 300, 150)
+
+
+def test_refresh_captures_the_new_full_screen_size():
+    grab = _spying_screenshot()
+    assert grab.capture().shape == (100, 200, 4)
+    grab._backend.size = (300, 150)
+    grab.refresh()
+    assert grab.capture().shape == (150, 300, 4)
+
+
+def test_refresh_asks_the_backend_to_re_resolve_its_display():
+    """macOS latches CGMainDisplayID at construction; it must re-read."""
+    grab = _spying_screenshot()
+    grab.refresh()
+    assert grab._backend.refreshed == 1
 
 
 def test_capture_full_screen_shape_and_dtype():

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -284,6 +284,28 @@ def test_refresh_captures_the_new_full_screen_size():
     assert grab.capture().shape == (150, 300, 4)
 
 
+def test_refresh_keeps_the_cache_when_the_backend_fails():
+    """A failed refresh must not leave the object worse than before.
+
+    The backend is asked first precisely so the cached size and buffer
+    survive when it raises, rather than being discarded in favour of
+    nothing.
+    """
+    grab = _spying_screenshot()
+    assert grab.screensize == (200, 100)
+    first = grab.capture()
+
+    def boom():
+        raise RuntimeError('display went away')
+
+    grab._backend.refresh = boom
+    with pytest.raises(RuntimeError, match='display went away'):
+        grab.refresh()
+
+    assert grab._screensize == (200, 100)
+    assert grab._img is first
+
+
 def test_refresh_asks_the_backend_to_re_resolve_its_display():
     """macOS latches CGMainDisplayID at construction; it must re-read."""
     grab = _spying_screenshot()

--- a/tests/test_wlr_backend.py
+++ b/tests/test_wlr_backend.py
@@ -1,10 +1,10 @@
 """Fake-state tests for the wlr backend that need no compositor.
 
 ``docker compose run --rm test-wayland`` exercises the real thing under
-headless ``cage``, but that session has a single output and never
-changes mode, so the paths :meth:`WlrBackend.refresh` exists for are
-unreachable there. These drive the same code over hand-built output
-state instead.
+headless ``cage``, but that session has a single unscaled, untransformed
+output and never changes mode, so the paths :meth:`WlrBackend.refresh`
+and the sub-region guard exist for are unreachable there. These drive
+the same code over hand-built output state instead.
 """
 from types import SimpleNamespace
 
@@ -19,6 +19,12 @@ from fastgrab.backends.wlr import WlrBackend  # noqa: E402
 
 # Hand-built output state only — no compositor, no display server.
 pytestmark = pytest.mark.no_display
+
+
+def _output(name="HDMI-1", mode_w=100, mode_h=50, scale=1, transform=0):
+    """An output as ``_connect_singleton`` would have accumulated it."""
+    return SimpleNamespace(name=name, mode_w=mode_w, mode_h=mode_h,
+                           scale=scale, transform=transform)
 
 
 def _fake_backend(outputs, on_roundtrip=None):
@@ -39,7 +45,7 @@ def _fake_backend(outputs, on_roundtrip=None):
 
 def test_refresh_picks_up_a_mode_change():
     """resolution() reads fields latched from events, not live state."""
-    output = SimpleNamespace(name="HDMI-1", mode_w=100, mode_h=50)
+    output = _output()
 
     def new_mode_arrives():
         output.mode_w, output.mode_h = 200, 120
@@ -54,8 +60,8 @@ def test_refresh_picks_up_a_mode_change():
 
 
 def test_refresh_reselects_the_requested_output(monkeypatch):
-    first = SimpleNamespace(name="HDMI-1", mode_w=100, mode_h=50)
-    second = SimpleNamespace(name="DP-1", mode_w=300, mode_h=150)
+    first = _output()
+    second = _output(name="DP-1", mode_w=300, mode_h=150)
     backend, _ = _fake_backend([first, second])
     assert backend._output is first
 
@@ -65,34 +71,47 @@ def test_refresh_reselects_the_requested_output(monkeypatch):
     assert backend.resolution() == (300, 150)
 
 
-def test_subregion_capture_is_refused_on_a_scaled_output():
-    """Device pixels and wlr-screencopy logical coordinates agree at 1x only.
+def test_refresh_raises_for_an_unknown_requested_output(monkeypatch):
+    backend, _ = _fake_backend([_output()])
 
-    The protocol takes the region in logical coordinates, so a 20x10
-    device-pixel request on a scale-2 output would be sent as 20x10
-    logical, come back as a 40x20 frame, and be displaced at the origin
-    too. Refusing beats returning the wrong pixels.
+    monkeypatch.setenv("FASTGRAB_OUTPUT", "DP-9")
+    with pytest.raises(RuntimeError, match="not found"):
+        backend.refresh()
+
+
+@pytest.mark.parametrize("output, why", [
+    (_output(scale=2), "a scale of 2 doubles the frame"),
+    (_output(transform=1), "a 90 degree rotation transposes it"),
+    (_output(transform=3), "270 degrees likewise"),
+    (_output(scale=2, transform=1), "both at once"),
+])
+def test_subregion_capture_is_refused_off_the_identity_mapping(output, why):
+    """The region is logical; device pixels match only at scale 1, no transform.
+
+    wlroots applies the output transform *before* the scale, so a
+    rotation breaks the correspondence even on an unscaled output — a
+    20x10 request comes back 10x20. Refusing beats returning the wrong
+    pixels, which is what a scale-only guard would have done here.
     """
-    output = SimpleNamespace(name="HDMI-1", mode_w=100, mode_h=50, scale=2)
     backend, _ = _fake_backend([output])
     with pytest.raises(NotImplementedError, match="logical coordinates"):
         backend.screenshot(0, 0, numpy.zeros((10, 20, 4), numpy.uint8))
 
 
-def test_full_output_capture_is_not_blocked_by_scale():
-    """Full-output capture goes via capture_output and takes no region."""
-    output = SimpleNamespace(name="HDMI-1", mode_w=100, mode_h=50, scale=2)
-    backend, _ = _fake_backend([output])
+def test_subregion_capture_is_allowed_on_an_identity_output():
+    """The guard must not block the case that actually works."""
+    backend, _ = _fake_backend([_output()])
     # No _screencopy on the fake, so reaching the capture call raises
-    # AttributeError -- which proves the scale guard did not fire.
+    # AttributeError — which proves the guard did not fire.
+    with pytest.raises(AttributeError):
+        backend.screenshot(0, 0, numpy.zeros((10, 20, 4), numpy.uint8))
+
+
+@pytest.mark.parametrize("output", [
+    _output(scale=2), _output(transform=1),
+])
+def test_full_output_capture_is_never_blocked_by_the_guard(output):
+    """capture_output takes no region, so scale and transform cannot bite."""
+    backend, _ = _fake_backend([output])
     with pytest.raises(AttributeError):
         backend.screenshot(0, 0, numpy.zeros((50, 100, 4), numpy.uint8))
-
-
-def test_refresh_raises_for_an_unknown_requested_output(monkeypatch):
-    output = SimpleNamespace(name="HDMI-1", mode_w=100, mode_h=50)
-    backend, _ = _fake_backend([output])
-
-    monkeypatch.setenv("FASTGRAB_OUTPUT", "DP-9")
-    with pytest.raises(RuntimeError, match="not found"):
-        backend.refresh()

--- a/tests/test_wlr_backend.py
+++ b/tests/test_wlr_backend.py
@@ -16,6 +16,9 @@ pytest.importorskip(
 
 from fastgrab.backends.wlr import WlrBackend  # noqa: E402
 
+# Hand-built output state only — no compositor, no display server.
+pytestmark = pytest.mark.no_display
+
 
 def _fake_backend(outputs, on_roundtrip=None):
     """A WlrBackend over fake output state, bypassing the connection."""

--- a/tests/test_wlr_backend.py
+++ b/tests/test_wlr_backend.py
@@ -23,8 +23,8 @@ pytestmark = pytest.mark.no_display
 
 def _output(name="HDMI-1", mode_w=100, mode_h=50, scale=1, transform=0):
     """An output as ``_connect_singleton`` would have accumulated it."""
-    return SimpleNamespace(name=name, mode_w=mode_w, mode_h=mode_h,
-                           scale=scale, transform=transform)
+    return SimpleNamespace(proxy=object(), name=name, mode_w=mode_w,
+                           mode_h=mode_h, scale=scale, transform=transform)
 
 
 def _fake_backend(outputs, on_roundtrip=None):
@@ -115,3 +115,68 @@ def test_full_output_capture_is_never_blocked_by_the_guard(output):
     backend, _ = _fake_backend([output])
     with pytest.raises(AttributeError):
         backend.screenshot(0, 0, numpy.zeros((50, 100, 4), numpy.uint8))
+
+
+class _FakeFrame:
+    """A zwlr_screencopy_frame_v1 that reports a fixed buffer size."""
+
+    def __init__(self, w, h):
+        self.dispatcher = {}
+        self.w, self.h = w, h
+        self.destroyed = False
+
+    def deliver_buffer(self):
+        # wl_shm ARGB8888 is format 0.
+        self.dispatcher["buffer"](self, 0, self.w, self.h, self.w * 4)
+        self.dispatcher["buffer_done"](self)
+
+    def destroy(self):
+        self.destroyed = True
+
+
+def _capture_backend(output, frame_w, frame_h):
+    """A backend faked just far enough to reach the frame-size check."""
+    backend, _ = _fake_backend([output])
+    frame = _FakeFrame(frame_w, frame_h)
+    backend._display = SimpleNamespace(
+        dispatch=lambda block=True: frame.deliver_buffer(),
+        roundtrip=lambda: None,
+    )
+    backend._screencopy = SimpleNamespace(
+        capture_output=lambda overlay, out: frame,
+        capture_output_region=lambda overlay, out, x, y, w, h: frame,
+    )
+    return backend, frame
+
+
+def test_frame_smaller_than_the_request_is_refused_before_the_copy():
+    """A fractionally scaled output cannot be caught by the up-front guard.
+
+    wl_output.scale is an integer event and wlroots reports ceil() of
+    the real scale, so an output at 0.75 announces scale 1 and looks
+    like identity. The compositor returns a smaller frame, and
+    ``img[:] = arr`` would *broadcast* a 1x1 frame across the 2x2
+    destination rather than failing — silently wrong pixels.
+    """
+    backend, frame = _capture_backend(_output(), frame_w=1, frame_h=1)
+    with pytest.raises(NotImplementedError, match="returned a 1x1 frame"):
+        backend.screenshot(0, 0, numpy.zeros((2, 2, 4), numpy.uint8))
+    assert frame.destroyed, "the frame must be released on the error path"
+
+
+def test_frame_size_is_checked_for_full_output_capture_too():
+    """The full-output path predicts the size exactly, so it can check it."""
+    backend, frame = _capture_backend(_output(), frame_w=50, frame_h=25)
+    with pytest.raises(NotImplementedError, match="returned a 50x25 frame"):
+        backend.screenshot(0, 0, numpy.zeros((50, 100, 4), numpy.uint8))
+    assert frame.destroyed
+
+
+def test_matching_frame_size_passes_the_check():
+    """The guard must not fire when the compositor returns what was asked."""
+    backend, _ = _capture_backend(_output(), frame_w=2, frame_h=2)
+    # Passing the size check, the capture goes on to _ensure_buffer,
+    # which needs a real wl_shm pool — reaching it proves the check
+    # allowed this through.
+    with pytest.raises(AttributeError):
+        backend.screenshot(0, 0, numpy.zeros((2, 2, 4), numpy.uint8))

--- a/tests/test_wlr_backend.py
+++ b/tests/test_wlr_backend.py
@@ -8,6 +8,7 @@ state instead.
 """
 from types import SimpleNamespace
 
+import numpy
 import pytest
 
 pytest.importorskip(
@@ -62,6 +63,30 @@ def test_refresh_reselects_the_requested_output(monkeypatch):
     backend.refresh()
     assert backend._output is second
     assert backend.resolution() == (300, 150)
+
+
+def test_subregion_capture_is_refused_on_a_scaled_output():
+    """Device pixels and wlr-screencopy logical coordinates agree at 1x only.
+
+    The protocol takes the region in logical coordinates, so a 20x10
+    device-pixel request on a scale-2 output would be sent as 20x10
+    logical, come back as a 40x20 frame, and be displaced at the origin
+    too. Refusing beats returning the wrong pixels.
+    """
+    output = SimpleNamespace(name="HDMI-1", mode_w=100, mode_h=50, scale=2)
+    backend, _ = _fake_backend([output])
+    with pytest.raises(NotImplementedError, match="logical coordinates"):
+        backend.screenshot(0, 0, numpy.zeros((10, 20, 4), numpy.uint8))
+
+
+def test_full_output_capture_is_not_blocked_by_scale():
+    """Full-output capture goes via capture_output and takes no region."""
+    output = SimpleNamespace(name="HDMI-1", mode_w=100, mode_h=50, scale=2)
+    backend, _ = _fake_backend([output])
+    # No _screencopy on the fake, so reaching the capture call raises
+    # AttributeError -- which proves the scale guard did not fire.
+    with pytest.raises(AttributeError):
+        backend.screenshot(0, 0, numpy.zeros((50, 100, 4), numpy.uint8))
 
 
 def test_refresh_raises_for_an_unknown_requested_output(monkeypatch):

--- a/tests/test_wlr_backend.py
+++ b/tests/test_wlr_backend.py
@@ -1,0 +1,70 @@
+"""Fake-state tests for the wlr backend that need no compositor.
+
+``docker compose run --rm test-wayland`` exercises the real thing under
+headless ``cage``, but that session has a single output and never
+changes mode, so the paths :meth:`WlrBackend.refresh` exists for are
+unreachable there. These drive the same code over hand-built output
+state instead.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip(
+    "pywayland", reason="the wlr backend is behind the [wayland] extra"
+)
+
+from fastgrab.backends.wlr import WlrBackend  # noqa: E402
+
+
+def _fake_backend(outputs, on_roundtrip=None):
+    """A WlrBackend over fake output state, bypassing the connection."""
+    backend = object.__new__(WlrBackend)
+    roundtrips = []
+
+    def roundtrip():
+        roundtrips.append(1)
+        if on_roundtrip is not None:
+            on_roundtrip()
+
+    backend._display = SimpleNamespace(roundtrip=roundtrip)
+    backend._outputs = outputs
+    backend._output = outputs[0]
+    return backend, roundtrips
+
+
+def test_refresh_picks_up_a_mode_change():
+    """resolution() reads fields latched from events, not live state."""
+    output = SimpleNamespace(name="HDMI-1", mode_w=100, mode_h=50)
+
+    def new_mode_arrives():
+        output.mode_w, output.mode_h = 200, 120
+
+    backend, roundtrips = _fake_backend([output], new_mode_arrives)
+    assert backend.resolution() == (100, 50)
+
+    backend.refresh()
+    assert backend.resolution() == (200, 120)
+    # two, matching what _connect_singleton does to let events settle
+    assert len(roundtrips) == 2
+
+
+def test_refresh_reselects_the_requested_output(monkeypatch):
+    first = SimpleNamespace(name="HDMI-1", mode_w=100, mode_h=50)
+    second = SimpleNamespace(name="DP-1", mode_w=300, mode_h=150)
+    backend, _ = _fake_backend([first, second])
+    assert backend._output is first
+
+    monkeypatch.setenv("FASTGRAB_OUTPUT", "DP-1")
+    backend.refresh()
+    assert backend._output is second
+    assert backend.resolution() == (300, 150)
+
+
+def test_refresh_raises_for_an_unknown_requested_output(monkeypatch):
+    output = SimpleNamespace(name="HDMI-1", mode_w=100, mode_h=50)
+    backend, _ = _fake_backend([output])
+
+    monkeypatch.setenv("FASTGRAB_OUTPUT", "DP-9")
+    with pytest.raises(RuntimeError, match="not found"):
+        backend.refresh()

--- a/tests/test_x11_lowlevel.py
+++ b/tests/test_x11_lowlevel.py
@@ -90,10 +90,47 @@ def test_low_level_screenshot_rejects_region_past_the_right_edge():
 
 
 def test_low_level_screenshot_rejects_empty_region():
-    with pytest.raises(RuntimeError, match="non-positive"):
+    with pytest.raises(ValueError, match="must be positive"):
         _linux_x11.screenshot(0, 0, numpy.zeros((0, 8, 4), dtype="uint8"))
 
 
 def test_screenshot_rejects_non_3d_buffer():
     with pytest.raises(ValueError, match="height, width, 4"):
         _linux_x11.screenshot(0, 0, numpy.zeros((8, 8), dtype=numpy.uint8))
+
+
+def test_screenshot_rejects_buffer_without_four_channels():
+    """Regression: this used to overrun the destination buffer.
+
+    Only ``ndim == 3`` was checked, so an (8, 8, 3) array was accepted
+    and the 32-bpp copy wrote 8*8*4 = 256 bytes into a 192-byte
+    allocation — a heap overflow through the advertised low-level API.
+    """
+    with pytest.raises(ValueError, match="height, width, 4"):
+        _linux_x11.screenshot(0, 0, numpy.zeros((8, 8, 3), dtype=numpy.uint8))
+
+
+def test_screenshot_rejects_wrong_dtype():
+    """Rejected, not coerced: a coerced copy would be filled and dropped."""
+    with pytest.raises(ValueError, match="dtype uint8"):
+        _linux_x11.screenshot(0, 0, numpy.zeros((8, 8, 4), dtype=numpy.float64))
+
+
+def test_screenshot_rejects_non_contiguous_buffer():
+    """A strided view cannot be filled in place, so it must not be taken."""
+    view = numpy.zeros((8, 16, 4), dtype=numpy.uint8)[:, ::2]
+    assert not view.flags["C_CONTIGUOUS"]  # sanity: the case under test
+    with pytest.raises(ValueError, match="C-contiguous"):
+        _linux_x11.screenshot(0, 0, view)
+
+
+def test_screenshot_rejects_read_only_buffer():
+    buf = numpy.zeros((8, 8, 4), dtype=numpy.uint8)
+    buf.flags.writeable = False
+    with pytest.raises(ValueError, match="C-contiguous|writable"):
+        _linux_x11.screenshot(0, 0, buf)
+
+
+def test_screenshot_rejects_non_array_buffer():
+    with pytest.raises(TypeError, match="ndarray"):
+        _linux_x11.screenshot(0, 0, [[0, 0, 0, 0]])

--- a/tests/test_x11_lowlevel.py
+++ b/tests/test_x11_lowlevel.py
@@ -66,6 +66,34 @@ def test_unreachable_display_raises_instead_of_segfaulting(monkeypatch):
         screenshot.Screenshot(backend="x11").capture()
 
 
+@pytest.mark.parametrize("x, y", [(-1, -1), (-1, 0), (0, -1)])
+def test_low_level_screenshot_rejects_negative_origin(x, y):
+    """Regression: a negative origin used to kill the interpreter.
+
+    It reaches XGetImage as a BadMatch, and X protocol errors are
+    delivered to Xlib's default error handler, which prints a
+    diagnostic and calls exit() — no exception, no traceback, and the
+    NULL check in the C code never gets a chance to run.
+    """
+    buf = numpy.zeros((8, 8, 4), dtype="uint8")
+    with pytest.raises(RuntimeError, match="outside the screen"):
+        _linux_x11.screenshot(x, y, buf)
+
+
+def test_low_level_screenshot_rejects_region_past_the_right_edge():
+    width, height = _linux_x11.resolution()
+    buf = numpy.zeros((8, 8, 4), dtype="uint8")
+    with pytest.raises(RuntimeError, match="outside the screen"):
+        _linux_x11.screenshot(width - 4, 0, buf)
+    with pytest.raises(RuntimeError, match="outside the screen"):
+        _linux_x11.screenshot(0, height - 4, buf)
+
+
+def test_low_level_screenshot_rejects_empty_region():
+    with pytest.raises(RuntimeError, match="non-positive"):
+        _linux_x11.screenshot(0, 0, numpy.zeros((0, 8, 4), dtype="uint8"))
+
+
 def test_screenshot_rejects_non_3d_buffer():
     with pytest.raises(ValueError, match="height, width, 4"):
         _linux_x11.screenshot(0, 0, numpy.zeros((8, 8), dtype=numpy.uint8))


### PR DESCRIPTION
Fixes #36.

## The bug

`MacosBackend.resolution()` read `CGDisplayPixelsWide/High`, which report the display mode in **points** — the logical desktop size. `CGDisplayCreateImage` returns the backing store, in **physical pixels**. On a Retina panel those differ by the scale factor, so `Screenshot.capture()` allocated a half-size buffer, got a full-size `CGImage` back, and **every capture on a Retina Mac raised**:

```
RuntimeError: CGImage size 3600x2338 does not match requested 1800x1169;
Retina scale-factor mismatch?
```

## The fix

**1. Report physical pixels.** `resolution()` now uses `CGDisplayCopyDisplayMode` + `CGDisplayModeGetPixelWidth/Height`, putting macOS on the same device-pixel contract as the x11 and wlr backends. The mode is read per capture rather than cached, so a resolution change or an external monitor is picked up on the next frame; it's released per the Core Foundation *copy* rule.

**2. Snap cropped rects outward.** Dividing by the scale factor is not sufficient. `CGDisplayCreateImageForRect` takes points but returns pixels, **and rounds a fractional rect outward**. Measured:

| requested rect (points) | returned image (pixels) |
|---|---|
| `(0, 0, 400, 300)` | 800x600 — exact |
| `(3.5, 6.5, 400.5, 300.5)` | 802x602 — asked for 801x601 |
| `(0.5, 0.5, 1.0, 1.0)` | 4x4 — asked for 2x2 |

So any `bbox` not aligned to the scale factor still failed, e.g. `capture(bbox=(7, 13, 801, 601))`. `_snap_rect_to_points()` rounds outward to whole points and reports where the requested region starts inside the result, which the copy then lifts out.

## Behaviour change

`resolution()` and `bbox` are now **device pixels** on macOS: a 1800x1169-point Retina desktop reports and captures 3600x2338. This is a visible change for anyone already working around the bug, but it is the only self-consistent option — points cannot describe what `CGDisplayCreateImage` returns — and it matches x11/wlr. Documented in the README and the module docstring.

## Testing

Verified live across a mixed-DPI setup — two 1x displays (1920x1080) and the built-in panel at 2x in two different scaled modes (1800x1169/3600x2338 and 1512x982/3024x1964):

- Full and cropped captures match the backing store on every display, including odd offsets and sizes down to a single pixel.
- Alignment probes over high-texture regions at odd offsets — which exercise the sub-rectangle copy — put the best match at zero shift everywhere. On the 2x panel: 0.011 at `(0,0)` against 1.32 at all four neighbours.
- The display-mode query is ~12us/frame **cheaper** than the `CGDisplayPixelsWide/High` pair it replaces (16us vs 28us, interleaved medians), and leaks nothing across 50k `resolution()` calls.
- **1x displays are unaffected**: at scale 1 `_snap_rect_to_points()` returns the rect unchanged with zero offsets, so the rect handed to CoreGraphics and both memmove branches are identical to before. Verified by running the same probe on `main` and on this branch across three displays — the two 1x monitors give byte-identical results; only the 2x panel changes (`main`: `resolution()`=(1512,982) and cropped capture raises; here: (3024,1964) and it works).

**19 new tests** in this commit, `pycodestyle` clean. The rect arithmetic is a pure function so it's tested directly; the copy path gets a small fake CoreGraphics. Neither needs macOS, a Retina display, or Screen Recording permission, so both run in CI everywhere.

The fake is deliberate rather than convenience: CI Macs are 1x, where `off_x`/`off_y` are identically 0, so the offset pointer arithmetic would otherwise never execute under test anywhere but physical Retina hardware.

## Notes

- Still main-display-only (`CGMainDisplayID`); multi-display via `Screenshot(display=N)` remains future work. I did confirm `CGDisplayCreateImageForRect` takes display-local (not global-desktop) coordinates, so nothing here blocks that.
- `CGDisplayPixelsWide/High` are no longer used and their prototypes were dropped.


---

> **Maintainer note**, added while reviewing (see the [review checklist](https://github.com/mherkazandjian/fastgrab/pull/37#issuecomment-5476488892) for the itemised list).
>
> The count above originally read "20 new tests"; `36d8af2` actually adds **19**, so it has been corrected in place.
>
> This branch now carries follow-up commits addressing the review findings — bbox validation and normalization, the exact full-screen size guard, provider and layout checks, hardening of the directly-callable backend and C entry points, `Screenshot.refresh()`, and a set of cleanups. As of `60c1c0c` the suite collects **168 tests** (158 run by default, 10 behind the `wayland` marker), of which **45** are in `tests/test_macos_backend.py`.
