### PR TITLE
docs: fix the matplotlib snippet to account for BGRA byte order

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ resolution    | fps
   from fastgrab import screenshot
   # take a full screen screenshot
   img = screenshot.Screenshot().capture()
-  # >> img is a numpy ndarray, do whatever you want with it
+  # >> img is a numpy ndarray of shape (height, width, 4) in BGRA byte order,
+  # >> do whatever you want with it
   # (optional)
   # e.g it can be displayed with matplotlib (install matplotlib first)
   from matplotlib import pyplot as plt
-  plt.imshow(img[:, :, 0:3], interpolation='none', cmap='Greys_r')
+  # matplotlib expects RGB, so reverse the BGR channels and drop alpha
+  plt.imshow(img[:, :, 2::-1], interpolation='none')
   plt.show()
 ````
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ resolution    | fps
   from fastgrab import screenshot
   # take a full screen screenshot
   img = screenshot.Screenshot().capture()
-  # >> img is a numpy ndarray of shape (height, width, 4) in BGRA byte order,
+  # >> img is a numpy ndarray of shape (height, width, 4) in BGRA byte order
   # >> do whatever you want with it
   # (optional)
   # e.g it can be displayed with matplotlib (install matplotlib first)

--- a/examples/low_level_api_screenshot.py
+++ b/examples/low_level_api_screenshot.py
@@ -13,6 +13,6 @@ screenshot(x, y, img)
 
 # (optional) view the screenshot
 # import pylab
-# matplotlib expects RGB, so reverse the BGR channels
+# matplotlib expects RGB, so reverse the BGR channels and drop alpha
 # pylab.imshow(img[:, :, 2::-1], interpolation='none')
 # pylab.show()

--- a/examples/low_level_api_screenshot.py
+++ b/examples/low_level_api_screenshot.py
@@ -13,5 +13,6 @@ screenshot(x, y, img)
 
 # (optional) view the screenshot
 # import pylab
-# pylab.imshow(img[:, :, 0:3], interpolation='none', cmap='Greys_r')
+# matplotlib expects RGB, so reverse the BGR channels
+# pylab.imshow(img[:, :, 2::-1], interpolation='none')
 # pylab.show()

--- a/examples/single_screenshot.py
+++ b/examples/single_screenshot.py
@@ -5,7 +5,7 @@ from fastgrab import screenshot
 img = screenshot.Screenshot().capture()
 
 # import pylab
-# matplotlib expects RGB, so reverse the BGR channels
+# matplotlib expects RGB, so reverse the BGR channels and drop alpha
 # pylab.imshow(img[:, :, 2::-1], interpolation='none')
 # pylab.show()
 

--- a/examples/single_screenshot.py
+++ b/examples/single_screenshot.py
@@ -5,6 +5,7 @@ from fastgrab import screenshot
 img = screenshot.Screenshot().capture()
 
 # import pylab
-# pylab.imshow(img[:, :, 0:3], interpolation='none', cmap='Greys_r')
+# matplotlib expects RGB, so reverse the BGR channels
+# pylab.imshow(img[:, :, 2::-1], interpolation='none')
 # pylab.show()
 

--- a/fastgrab/screenshot.py
+++ b/fastgrab/screenshot.py
@@ -221,7 +221,8 @@ class Screenshot(object):
             img = grab.capture()
 
             from matplotlib import pyplot as plt
-            plt.imshow(img[:, :, 0:3], interpolation='none', cmap='Greys_r')
+            # matplotlib expects RGB, so reverse the BGR channels
+            plt.imshow(img[:, :, 2::-1], interpolation='none')
             plt.show()
 
         :param bbox: the upper left corner of the screenshot and the width

--- a/fastgrab/screenshot.py
+++ b/fastgrab/screenshot.py
@@ -221,7 +221,7 @@ class Screenshot(object):
             img = grab.capture()
 
             from matplotlib import pyplot as plt
-            # matplotlib expects RGB, so reverse the BGR channels
+            # matplotlib expects RGB, so reverse the BGR channels and drop alpha
             plt.imshow(img[:, :, 2::-1], interpolation='none')
             plt.show()
 


### PR DESCRIPTION
## What

The usage snippet in the README, the `Screenshot.capture()` docstring and both scripts in
`examples/` all showed the same line:

```python
plt.imshow(img[:, :, 0:3], interpolation='none', cmap='Greys_r')
```

It is wrong in two independent ways.

**1. The colours come out swapped.** Every backend fills the buffer in BGRA byte order — B=0, G=1,
R=2, A=3, as `capture()`'s own docstring says and as the integration tests assert
(`tests/test_integration.py:17`, `tests/test_integration_wlr.py:23`). Slicing `0:3` therefore hands
matplotlib B, G, R while matplotlib reads it as R, G, B. A red screen displays blue.

**2. `cmap='Greys_r'` does nothing.** matplotlib only applies a colormap to 2-D scalar data; this
array is 3-channel, so the argument is silently ignored. Mostly it is evidence the snippet had never
been run as written.

## The fix

```python
# matplotlib expects RGB, so reverse the BGR channels and drop alpha
plt.imshow(img[:, :, 2::-1], interpolation='none')
```

Applied in all four places, plus one line in the README stating that the array is BGRA so the
reversal has a visible reason.

No behaviour change — documentation and commented-out example lines only.

## Verification

Ran in the dev container (`docker compose`, never on the host): painted the X root with three solid
stripes — red on top, green in the middle, blue at the bottom — captured via the public two-line API,
then rendered the array both ways.

Buffer contents at the centre of each stripe:

| painted | `img[y, x]` → (0, 1, 2, 3) |
| --- | --- |
| red    | `(0, 0, 255, 0)` |
| green  | `(0, 255, 0, 0)` |
| blue   | `(255, 0, 0, 0)` |

That is BGRA, with alpha zeroed as documented.

Rendering the capture with the **old** line puts blue on top and red at the bottom — the painted
order inverted. Rendering with `2::-1` reproduces red-top / green-middle / blue-bottom, matching what
was actually painted. Both PNGs were inspected visually, not just compared numerically.

Also confirmed that `imshow` on the `(H, W, 3)` slice keeps `ndim == 3`, so the colormap argument
never applies.

`docker compose run --rm test` → **168 passed, 10 deselected**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLmJd7aNG8CRS7EQ9waLqD