### PR TITLE
ci: publish to PyPI from a GitHub Release via trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,96 @@
+name: release
+
+# Publishing runs from a published GitHub Release -- the release is the
+# deliberate human step, so a plain push can never ship a version.
+# workflow_dispatch is the rehearsal path: it targets TestPyPI by default so
+# the whole pipeline can be exercised without burning a version number, which
+# matters because PyPI never allows a filename to be reused, even after the
+# release is deleted.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "Index to publish to"
+        type: choice
+        options:
+          - testpypi
+          - pypi
+        default: testpypi
+
+jobs:
+  build:
+    name: build sdist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install poetry and twine
+        run: |
+          pipx install poetry
+          pipx install twine
+
+      # Deliberately NOT `python -m build`. The repo root holds build.py
+      # (poetry's build hook) and `-m` puts the cwd on sys.path, so that name
+      # shadows the build frontend: the command compiles the extension
+      # in-place and exits 0 having produced no sdist at all.
+      - name: Build sdist
+        run: poetry build --format sdist
+
+      # Only an sdist is published, matching 0.1.0 and 0.2.0. A wheel built
+      # here would carry this runner's glibc in its manylinux tag without
+      # having been through auditwheel, and poetry-core emits a portable
+      # py3-none-any wheel on any non-Linux host -- which pip would prefer
+      # over the sdist on Linux and hand those users a package with no C
+      # extension. Real manylinux wheels need cibuildwheel + auditwheel.
+      - name: Check package metadata
+        run: twine check dist/*
+
+      # A tag that disagrees with pyproject.toml ships the wrong version
+      # under a filename that can never be reused.
+      - name: Verify the tag matches the packaged version
+        if: github.event_name == 'release'
+        run: |
+          packaged=$(python -c "import tomllib, pathlib; print(tomllib.loads(pathlib.Path('pyproject.toml').read_text())['tool']['poetry']['version'])")
+          tag="${GITHUB_REF_NAME#v}"
+          echo "packaged=${packaged}  tag=${tag}"
+          if [ "${packaged}" != "${tag}" ]; then
+            echo "::error::tag ${tag} does not match pyproject version ${packaged}"
+            exit 1
+          fi
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/
+
+  publish:
+    name: publish to ${{ github.event_name == 'release' && 'pypi' || inputs.target }}
+    needs: build
+    runs-on: ubuntu-latest
+
+    # The environment is what PyPI's trusted publisher config is pinned to,
+    # and it is where a required-reviewer rule can gate the upload.
+    environment: ${{ github.event_name == 'release' && 'pypi' || inputs.target }}
+
+    permissions:
+      # Mints the short-lived OIDC token that PyPI exchanges for an upload
+      # token. This is the whole point of trusted publishing: no long-lived
+      # API key exists to leak.
+      id-token: write
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: sdist
+          path: dist/
+
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: ${{ (github.event_name == 'release' || inputs.target == 'pypi') && 'https://upload.pypi.org/legacy/' || 'https://test.pypi.org/legacy/' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,9 @@ jobs:
     name: build sdist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
@@ -64,10 +64,14 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/upload-artifact@v4
+      # if-no-files-found defaults to `warn`, which would let an empty
+      # dist/ sail past and fail later, further from the cause -- exactly
+      # the shape of the `python -m build` trap above.
+      - uses: actions/upload-artifact@v7
         with:
           name: sdist
           path: dist/
+          if-no-files-found: error
 
   publish:
     name: publish to ${{ github.event_name == 'release' && 'pypi' || inputs.target }}
@@ -85,7 +89,7 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: sdist
           path: dist/


### PR DESCRIPTION
Adds `.github/workflows/release.yml`. No API token anywhere — the publish job mints a short-lived
OIDC identity that PyPI exchanges for an upload token.

## Design decisions

**Trigger.** Fires only on a *published* GitHub Release, so no push can ship a version.
`workflow_dispatch` targets TestPyPI by default so the pipeline can be rehearsed without burning a
version number — PyPI never allows a filename to be reused, even after the release is deleted.

**sdist only**, matching 0.1.0 and 0.2.0. A wheel built on a runner carries that runner's glibc in a
manylinux tag it never earned (nothing runs auditwheel), and poetry-core emits a `py3-none-any` wheel
on any non-Linux host — which pip would prefer over the sdist on Linux and hand those users a package
with no C extension. Proper manylinux wheels need cibuildwheel + auditwheel; that's a separate piece
of work and the real fix for the open install issues.

## Two traps encoded in the workflow

1. It builds with `poetry build --format sdist`, **not** `python -m build`. The repo root holds
   `build.py` (poetry's build hook) and `-m` puts the cwd on `sys.path`, so that name shadows the
   build frontend: the command compiles the extension in place and exits 0 having produced no sdist
   at all. Found this the hard way while validating.
2. On a release, the tag is checked against `pyproject.toml`'s version before anything uploads.

## Validation

The sdist this workflow produces was built from a clean `git archive` export and installed in a
fresh `python:3.11-slim` container with only the advertised build deps (`build-essential`,
`libx11-dev`):

- `twine check` — PASSED
- compiles from source, `Successfully built fastgrab`
- two-line API works: `capture ok: (600, 800, 4) uint8`, `version: 0.3.0`
- contains `screenshot.c`; no stale `.so` leaked into the tarball

Workflow YAML parsed and asserted (`jobs`, triggers, `id-token: write`).

## Not in this PR

- The PyPI-side trusted publisher config and the `pypi` / `testpypi` GitHub environments — those are
  console steps.
- A note about the release flow for `.claude/CLAUDE.md`, which is gitignored here and tracked
  separately.
- Incidental finding: `build.py` links `gomp`, but the compiled `.so`'s `NEEDED` is only
  `libX11.so.6` and `libc.so.6` — the linker drops it. The documented `libgomp1` runtime dep is
  stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLmJd7aNG8CRS7EQ9waLqD