### PR TITLE
windows: make capture DPI-aware so coordinates are device pixels

### DIFF
--- a/fastgrab/backends/base.py
+++ b/fastgrab/backends/base.py
@@ -32,12 +32,17 @@ promise the code keeps:
   before the scale, so a rotation transposes the frame even at scale 1.
   The backend refuses a sub-region request on any other output rather
   than returning the wrong one. See issue #38.
-* ``windows`` reports and captures in whatever DPI context the host
-  process happens to have. Windows virtualizes screen metrics for
-  DPI-unaware threads and ``BitBlt`` takes logical units, and neither
-  the backend nor CPython's manifest establishes per-monitor awareness,
-  so at a display scale other than 100% these are not physical pixels.
-  See issue #39.
+* ``windows`` honours it on Windows 10 1607 and later, where the
+  backend temporarily gives its own thread per-monitor-v2 DPI
+  awareness around the metrics query, the screen-DC acquisition and
+  the blit, so neither the host process's DPI context nor the display
+  scale changes what it reports or captures. On older Windows
+  ``SetThreadDpiAwarenessContext`` does not exist; there the backend
+  falls back to the host's context and, at a display scale other than
+  100%, back to logical units. Primary monitor only in either case —
+  the desktop DC's origin is the primary monitor's top-left, and
+  reaching a second monitor at its own scale is the future
+  ``Screenshot(display=N)`` feature, not a DPI question.
 * ``portal`` is a placeholder that raises ``NotImplementedError``.
 """
 from abc import ABC, abstractmethod

--- a/fastgrab/backends/windows.py
+++ b/fastgrab/backends/windows.py
@@ -9,12 +9,29 @@ V1 captures from the **primary** monitor only. Multi-monitor capture
 via ``SM_CXVIRTUALSCREEN`` / ``EnumDisplayMonitors`` is a future
 ``Screenshot(display=N)`` extension.
 
+**DPI.** :mod:`fastgrab.backends.base` promises device pixels, and Win32
+only tells the truth to a DPI-aware caller: ``GetSystemMetrics`` is
+virtualized to 96 DPI for a DPI-unaware thread, and ``BitBlt`` against
+the desktop reads the virtualized (stretched) surface, so at a 150%
+display scale both would speak logical units. CPython's manifest
+declares no awareness, so an unpatched process inherits "unaware" and
+what fastgrab reported would depend on whatever host application
+happened to embed it.
+
+The fix is :func:`_thread_dpi_aware`: per-monitor-v2 awareness is set on
+the **calling thread only**, for the duration of the metrics query, the
+screen-DC acquisition and the blit, then restored. Process-wide
+awareness (``SetProcessDpiAwarenessContext``) is deliberately not used —
+it is a one-shot, irreversible property that would silently re-scale the
+UI of any application that merely imported fastgrab.
+
 Byte order matches the rest of fastgrab: 32-bpp ``BITMAPINFOHEADER`` on
 little-endian Windows lays each pixel out as B, G, R, A in memory, so
 the captured numpy array is BGRA — same contract as X11 and wlr.
 """
 from __future__ import annotations
 
+import contextlib
 import ctypes
 from ctypes import wintypes  # only available on Windows; gated by importer
 
@@ -28,6 +45,12 @@ _SRCCOPY = 0x00CC0020
 _CAPTUREBLT = 0x40000000
 _BI_RGB = 0
 _DIB_RGB_COLORS = 0
+
+# DPI_AWARENESS_CONTEXT is an opaque HANDLE whose predefined values are
+# small negative integers cast to a pointer (<winuser.h>). -4 is
+# DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2, the only context that
+# reports true physical pixels on every monitor of a mixed-DPI desktop.
+_DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2 = wintypes.HANDLE(-4)
 
 
 class _BITMAPINFOHEADER(ctypes.Structure):
@@ -65,6 +88,19 @@ def _load_libs():
     user32.ReleaseDC.argtypes = [wintypes.HWND, wintypes.HDC]
     user32.ReleaseDC.restype = ctypes.c_int
 
+    # Windows 10 1607+. Older systems simply do not export it, and
+    # ctypes resolves exports lazily through __getattr__ — so probe with
+    # getattr rather than calling it and catching the failure, which on a
+    # partially-applied call could leave a changed context on the thread.
+    set_dpi_ctx = getattr(user32, "SetThreadDpiAwarenessContext", None)
+    if set_dpi_ctx is not None:
+        set_dpi_ctx.argtypes = [wintypes.HANDLE]
+        # Returns the thread's PREVIOUS context, or NULL if the value
+        # passed in was invalid. That return is the whole "save" half of
+        # save/restore, which is why GetThreadDpiAwarenessContext is not
+        # wired up here.
+        set_dpi_ctx.restype = wintypes.HANDLE
+
     gdi32.CreateCompatibleDC.argtypes = [wintypes.HDC]
     gdi32.CreateCompatibleDC.restype = wintypes.HDC
     gdi32.DeleteDC.argtypes = [wintypes.HDC]
@@ -93,15 +129,53 @@ def _load_libs():
     return user32, gdi32
 
 
+@contextlib.contextmanager
+def _thread_dpi_aware(user32):
+    """Make the calling thread per-monitor-v2 DPI aware for the block.
+
+    Scoped to this thread, and restored on the way out even if the body
+    raises — fastgrab is a library, and leaving a changed DPI context
+    behind on a thread it does not own would re-scale the caller's own
+    windows.
+
+    Degrades to a no-op on Windows earlier than 10 1607, where
+    ``SetThreadDpiAwarenessContext`` does not exist, and on the
+    documented NULL return that says the context value was rejected. In
+    both cases nothing was changed, so there is nothing to restore and
+    the caller simply gets the host process's context — the pre-fix
+    behaviour, rather than a crash.
+
+    Yields whether awareness was actually established.
+    """
+    set_dpi_ctx = getattr(user32, "SetThreadDpiAwarenessContext", None)
+    previous = None
+    if set_dpi_ctx is not None:
+        previous = set_dpi_ctx(_DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)
+    try:
+        yield bool(previous)
+    finally:
+        if previous:
+            set_dpi_ctx(previous)
+
+
 class WindowsBackend(BaseBackend):
     def __init__(self):
         self._user32, self._gdi32 = _load_libs()
-        self._screen_dc = self._user32.GetDC(None)
-        if not self._screen_dc:
-            raise RuntimeError("GetDC(NULL) returned 0; cannot access screen")
-        self._mem_dc = self._gdi32.CreateCompatibleDC(self._screen_dc)
+
+        # The memory DC is built once and kept: CreateCompatibleDC copies
+        # the device's characteristics, so the DC it returns outlives the
+        # screen DC it was derived from and carries no DPI context of its
+        # own (DPI virtualization applies to on-screen surfaces, not to
+        # memory bitmaps).
+        with _thread_dpi_aware(self._user32):
+            screen_dc = self._user32.GetDC(None)
+            if not screen_dc:
+                raise RuntimeError("GetDC(NULL) returned 0; cannot access screen")
+            try:
+                self._mem_dc = self._gdi32.CreateCompatibleDC(screen_dc)
+            finally:
+                self._user32.ReleaseDC(None, screen_dc)
         if not self._mem_dc:
-            self._user32.ReleaseDC(None, self._screen_dc)
             raise RuntimeError("CreateCompatibleDC failed")
 
         # cached DIBSection state — reused when (w, h) match the prior call.
@@ -114,8 +188,19 @@ class WindowsBackend(BaseBackend):
     # -------- BaseBackend API --------
 
     def resolution(self):
-        w = self._user32.GetSystemMetrics(_SM_CXSCREEN)
-        h = self._user32.GetSystemMetrics(_SM_CYSCREEN)
+        # SM_CXSCREEN/SM_CYSCREEN, not the SM_CXVIRTUALSCREEN family:
+        # this backend blits from the desktop DC, whose origin is the
+        # primary monitor's top-left, so reporting the virtual screen
+        # would hand the caller a bbox space that does not match the one
+        # screenshot() indexes — the virtual screen extends into negative
+        # coordinates when a monitor sits left of or above the primary.
+        # Reconciling the two is the Screenshot(display=N) feature, not
+        # this one. Under the per-monitor-v2 context these are the
+        # primary monitor's physical pixels; outside it they would be
+        # 96-DPI logical units.
+        with _thread_dpi_aware(self._user32):
+            w = self._user32.GetSystemMetrics(_SM_CXSCREEN)
+            h = self._user32.GetSystemMetrics(_SM_CYSCREEN)
         return (int(w), int(h))
 
     def bytes_per_pixel(self):
@@ -125,13 +210,33 @@ class WindowsBackend(BaseBackend):
         h, w, _ = img.shape
         self._ensure_bitmap(w, h)
 
-        ok = self._gdi32.BitBlt(
-            self._mem_dc, 0, 0, w, h,
-            self._screen_dc, int(x), int(y),
-            _SRCCOPY | _CAPTUREBLT,
-        )
+        # The screen DC is acquired inside the awareness scope and let go
+        # again on the way out rather than cached across calls: a DC
+        # handed to a DPI-unaware thread keeps reading the virtualized
+        # desktop regardless of which context is in force when BitBlt
+        # finally runs, so a DC cached at construction time would quietly
+        # undo this fix for anybody who built the backend from an unaware
+        # thread. The caching that makes this backend fast is the
+        # DIBSection and its memory DC, and both are untouched; a
+        # GetDC/ReleaseDC pair costs microseconds against a blit measured
+        # in milliseconds. It also stops fastgrab from sitting on a
+        # common-cache DC for the life of the process.
+        with _thread_dpi_aware(self._user32):
+            screen_dc = self._user32.GetDC(None)
+            if not screen_dc:
+                raise RuntimeError("GetDC(NULL) returned 0; cannot access screen")
+            try:
+                ok = self._gdi32.BitBlt(
+                    self._mem_dc, 0, 0, w, h,
+                    screen_dc, int(x), int(y),
+                    _SRCCOPY | _CAPTUREBLT,
+                )
+                # Read before ReleaseDC: that call goes through the same
+                # use_last_error=True handle and would overwrite it.
+                err = 0 if ok else ctypes.get_last_error()
+            finally:
+                self._user32.ReleaseDC(None, screen_dc)
         if not ok:
-            err = ctypes.get_last_error()
             raise RuntimeError("BitBlt failed (GetLastError={})".format(err))
 
         nbytes = w * h * 4
@@ -190,6 +295,7 @@ class WindowsBackend(BaseBackend):
         self._cur_w = w
         self._cur_h = h
 
-    # No __del__: matching the wlr backend, we let the OS reclaim DC and
-    # bitmap handles at process exit. Explicit cleanup paths are race-prone
-    # under interpreter shutdown.
+    # No __del__: matching the wlr backend, we let the OS reclaim the
+    # memory DC and bitmap handles at process exit. Explicit cleanup
+    # paths are race-prone under interpreter shutdown. The screen DC is
+    # no longer among them — it is released on every capture.

--- a/tests/test_windows_backend.py
+++ b/tests/test_windows_backend.py
@@ -1,0 +1,514 @@
+"""Tests for the Windows backend: the DPI-awareness scope around Win32.
+
+Win32 only reports device pixels to a DPI-aware caller, so the backend
+temporarily gives its own thread per-monitor-v2 awareness around the
+metrics query, the screen-DC acquisition and the blit. None of that can
+run on the Linux CI container, so ``user32``/``gdi32`` are faked and
+``ctypes.wintypes`` is stubbed in (it refuses to import off Windows).
+
+The fakes model Win32 where it is *unforgiving*, the way the macOS
+backend's fakes do:
+
+* the thread's DPI context is real state — ``GetSystemMetrics`` returns
+  96-DPI-virtualized numbers whenever the thread is unaware, so a
+  missing or leaked context switch shows up as wrong values rather than
+  only as an un-asserted call log;
+* a screen DC remembers the awareness it was acquired under, and
+  ``BitBlt`` serves the virtualized desktop for a DC acquired by an
+  unaware thread no matter what context is in force at blit time —
+  which is exactly why the cached screen DC had to go, and which a call
+  log cannot see at all;
+* ``ReleaseDC`` clobbers the shared last-error value the way a second
+  call through a ``use_last_error=True`` handle does, so reading
+  ``GetLastError`` in the wrong order reports the wrong code;
+* an out-of-range blit raises instead of letting numpy clip it into a
+  short, silently zero-padded region;
+* ``SetThreadDpiAwarenessContext`` is bound in ``__init__`` rather than
+  defined on the class, so ``dpi_api=False`` models an older Windows by
+  genuinely not having the export — a bare call would raise
+  ``AttributeError`` here just as it would there.
+"""
+import ctypes
+import sys
+import types
+
+import numpy
+import pytest
+
+
+def _stub_wintypes():
+    """The ``ctypes.wintypes`` names the backend needs, off Windows.
+
+    ``import ctypes.wintypes`` raises on non-Windows (``VARIANT_BOOL``'s
+    ``_type_ = "v"`` is unsupported there), which would take this whole
+    module down at collection time. The aliases below are the real
+    definitions verbatim, so the structure layouts under test are the
+    ones Windows would build.
+    """
+    stub = types.ModuleType("ctypes.wintypes")
+    stub.BYTE = ctypes.c_byte
+    stub.WORD = ctypes.c_ushort
+    stub.DWORD = ctypes.c_ulong
+    stub.LONG = ctypes.c_long
+    stub.UINT = ctypes.c_uint
+    stub.BOOL = ctypes.c_long
+    stub.HANDLE = ctypes.c_void_p
+    for alias in ("HWND", "HDC", "HBITMAP", "HGDIOBJ"):
+        setattr(stub, alias, stub.HANDLE)
+    return stub
+
+
+try:  # pragma: no cover - one branch per platform
+    from ctypes import wintypes as _wintypes  # noqa: F401
+except (ImportError, ValueError):
+    _stub = _stub_wintypes()
+    sys.modules.setdefault("ctypes.wintypes", _stub)
+    ctypes.wintypes = _stub
+
+from fastgrab.backends import windows  # noqa: E402
+from fastgrab.backends.windows import (  # noqa: E402
+    WindowsBackend,
+    _BITMAPINFO,
+    _DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2,
+    _SM_CXSCREEN,
+    _SM_CYSCREEN,
+    _thread_dpi_aware,
+)
+
+# Fakes all the way down — no Win32, no display server, any platform.
+pytestmark = pytest.mark.no_display
+
+
+def _handle_value(context):
+    """The integer a DPI_AWARENESS_CONTEXT handle carries."""
+    return getattr(context, "value", context)
+
+
+_PER_MONITOR_AWARE_V2 = _handle_value(_DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2)
+# DPI_AWARENESS_CONTEXT_UNAWARE — what a stock CPython process inherits,
+# and what the backend must hand back when it is done.
+_HOST_CONTEXT = ctypes.c_void_p(-1).value
+
+# A 64x48-pixel panel driven at 200%, so a DPI-unaware caller sees 32x24.
+PHYSICAL = (64, 48)
+SCALE = 2
+
+_DEFAULT_BITMAP = 0x4000
+_BITBLT_ERROR = 5
+
+# Stands in for the thread's Win32 last-error slot, which every call
+# through a use_last_error=True handle overwrites.
+_LAST_ERROR = {"code": 0}
+
+
+class _FakeUser32:
+    """The user32 surface the backend touches, over a real DPI context."""
+
+    def __init__(self, physical=PHYSICAL, scale=SCALE, dpi_api=True,
+                 get_dc_returns=None):
+        self.physical_w, self.physical_h = physical
+        self.scale = scale
+        self.screen = numpy.random.default_rng(0).integers(
+            0, 256, (self.physical_h, self.physical_w, 4), dtype=numpy.uint8)
+        # What a DPI-unaware caller is shown: the desktop stretched down
+        # to 96 DPI. Nearest-neighbour is enough to make it distinguishable
+        # from the real backing store.
+        self.virtual_screen = self.screen[::scale, ::scale]
+
+        self.thread_context = _HOST_CONTEXT
+        self.context_log = []
+
+        self.get_dc_returns = get_dc_returns
+        self._dc_serial = 0
+        self.dc_awareness = {}   # every hdc ever handed out
+        self.live_dcs = set()    # the ones not released yet
+        self.released_dcs = []
+
+        if dpi_api:
+            # Bound here, not defined on the class: dpi_api=False must
+            # look like an export that is simply not there.
+            self.SetThreadDpiAwarenessContext = self._set_thread_dpi
+
+    # -------- DPI awareness --------
+
+    def _set_thread_dpi(self, context):
+        self.context_log.append(_handle_value(context))
+        previous, self.thread_context = self.thread_context, context
+        return previous
+
+    def aware(self):
+        return _handle_value(self.thread_context) == _PER_MONITOR_AWARE_V2
+
+    # -------- metrics --------
+
+    def GetSystemMetrics(self, index):
+        w, h = self.physical_w, self.physical_h
+        if not self.aware():
+            # Windows virtualizes screen metrics for a DPI-unaware thread.
+            w, h = w // self.scale, h // self.scale
+        return {_SM_CXSCREEN: w, _SM_CYSCREEN: h}[index]
+
+    # -------- device contexts --------
+
+    def GetDC(self, hwnd):
+        assert hwnd is None, "the backend only ever asks for the screen DC"
+        if self.get_dc_returns is not None:
+            return self.get_dc_returns
+        self._dc_serial += 1
+        hdc = 0x1000 + self._dc_serial
+        # Latched at acquisition: this is the property a cached DC would
+        # carry forward across a later context switch.
+        self.dc_awareness[hdc] = self.aware()
+        self.live_dcs.add(hdc)
+        return hdc
+
+    def ReleaseDC(self, hwnd, hdc):
+        assert hdc in self.live_dcs, \
+            "released a DC that was never acquired (or released twice)"
+        self.live_dcs.discard(hdc)
+        self.released_dcs.append(hdc)
+        _LAST_ERROR["code"] = 0
+        return 1
+
+
+class _FakeGdi32:
+    """The gdi32 surface, blitting out of the user32 fake's screen."""
+
+    def __init__(self, user32):
+        self._user32 = user32
+        self.blits = []
+        self.bitblt_returns = 1
+        self.selected = _DEFAULT_BITMAP
+        self.buffers = {}         # HBITMAP -> (ctypes buffer, w, h)
+        self.created_bitmaps = []
+        self.deleted_bitmaps = []
+        self._bitmap_serial = 0
+
+    def CreateCompatibleDC(self, hdc):
+        assert hdc, "a memory DC must be built from a live screen DC"
+        return 0x2000
+
+    def CreateDIBSection(self, hdc, bmi, usage, bits_ptr, section, offset):
+        # ctypes.byref() wraps the argument in a CArgObject; the fake
+        # reads the original back out rather than pretending to be C.
+        header = getattr(bmi, "_obj", bmi).bmiHeader
+        out = getattr(bits_ptr, "_obj", bits_ptr)
+        assert header.biHeight < 0, "the DIB must stay top-down"
+        w, h = header.biWidth, -header.biHeight
+        buf = (ctypes.c_ubyte * (w * h * 4))()
+        self._bitmap_serial += 1
+        bitmap = 0x3000 + self._bitmap_serial
+        self.buffers[bitmap] = (buf, w, h)
+        self.created_bitmaps.append(bitmap)
+        out.value = ctypes.addressof(buf)
+        return bitmap
+
+    def SelectObject(self, hdc, hgdiobj):
+        previous, self.selected = self.selected, hgdiobj
+        return previous
+
+    def DeleteObject(self, hgdiobj):
+        self.deleted_bitmaps.append(hgdiobj)
+        return 1
+
+    def BitBlt(self, dst, dx, dy, w, h, src, sx, sy, rop):
+        src_aware = self._user32.dc_awareness[src]
+        self.blits.append(dict(dst=dst, dx=dx, dy=dy, w=w, h=h, src=src,
+                               sx=sx, sy=sy, rop=rop, src_aware=src_aware,
+                               thread_aware=self._user32.aware()))
+        if not self.bitblt_returns:
+            _LAST_ERROR["code"] = _BITBLT_ERROR
+            return 0
+        # A DC acquired by a DPI-unaware thread keeps reading the
+        # virtualized desktop however aware the thread has since become.
+        source = (self._user32.screen if src_aware
+                  else self._user32.virtual_screen)
+        max_h, max_w = source.shape[:2]
+        if sx < 0 or sy < 0 or sx + w > max_w or sy + h > max_h:
+            # numpy would clip this to a short region and leave the rest
+            # of the DIB zeroed — a silently "valid" capture.
+            raise AssertionError(
+                "blit of %r falls outside the %dx%d surface this DC sees"
+                % ((sx, sy, w, h), max_w, max_h))
+        buf, buf_w, buf_h = self.buffers[self.selected]
+        assert (buf_w, buf_h) == (w, h), "the blit does not fill the DIBSection"
+        region = numpy.ascontiguousarray(source[sy:sy + h, sx:sx + w])
+        ctypes.memmove(buf, region.ctypes.data, region.nbytes)
+        return 1
+
+
+@pytest.fixture(autouse=True)
+def _last_error(monkeypatch):
+    """``ctypes.get_last_error`` is Windows-only; the error paths call it."""
+    _LAST_ERROR["code"] = 0
+    monkeypatch.setattr(ctypes, "get_last_error",
+                        lambda: _LAST_ERROR["code"], raising=False)
+
+
+@pytest.fixture
+def make_backend(monkeypatch):
+    """Build a WindowsBackend over fakes, running its real ``__init__``."""
+    made = []
+
+    def _make(**kwargs):
+        user32 = _FakeUser32(**kwargs)
+        gdi32 = _FakeGdi32(user32)
+        made.append((user32, gdi32))
+        monkeypatch.setattr(windows, "_load_libs", lambda: (user32, gdi32))
+        return WindowsBackend(), user32, gdi32
+
+    _make.fakes = made
+    return _make
+
+
+def _capture(backend, x, y, w, h):
+    img = numpy.zeros((h, w, 4), numpy.uint8)
+    backend.screenshot(x, y, img)
+    return img
+
+
+def _bmi(w, h):
+    bmi = _BITMAPINFO()
+    bmi.bmiHeader.biWidth = w
+    bmi.bmiHeader.biHeight = -h
+    return ctypes.byref(bmi)
+
+
+# -------- resolution() --------
+
+def test_resolution_reports_physical_pixels_at_a_200_percent_scale(make_backend):
+    """The bug: an unaware thread is shown 32x24 for a 64x48 panel."""
+    backend, user32, _ = make_backend()
+    # queried outside the backend's scope, i.e. what it used to see
+    assert user32.GetSystemMetrics(_SM_CXSCREEN) == 32
+    assert backend.resolution() == PHYSICAL
+
+
+def test_resolution_sets_and_restores_the_thread_dpi_context(make_backend):
+    backend, user32, _ = make_backend()
+    before = len(user32.context_log)
+    assert backend.resolution() == PHYSICAL
+    assert user32.context_log[before:] == [_PER_MONITOR_AWARE_V2, _HOST_CONTEXT]
+    assert user32.thread_context == _HOST_CONTEXT
+
+
+def test_resolution_restores_the_thread_dpi_context_when_it_raises(make_backend):
+    """A library must not leave a changed DPI context on the caller."""
+    backend, user32, _ = make_backend()
+
+    def boom(index):
+        raise OSError("GetSystemMetrics failed")
+
+    user32.GetSystemMetrics = boom
+    with pytest.raises(OSError):
+        backend.resolution()
+    assert user32.thread_context == _HOST_CONTEXT
+
+
+def test_resolution_falls_back_when_the_dpi_api_is_missing(make_backend):
+    """Windows before 10 1607: no export, so the host context stands."""
+    backend, user32, _ = make_backend(dpi_api=False)
+    assert user32.context_log == []
+    assert backend.resolution() == (32, 24)   # virtualized, as before the fix
+
+
+# -------- screenshot() --------
+
+def test_screenshot_sets_and_restores_the_thread_dpi_context(make_backend):
+    backend, user32, _ = make_backend()
+    before = len(user32.context_log)
+    _capture(backend, 0, 0, 8, 6)
+    assert user32.context_log[before:] == [_PER_MONITOR_AWARE_V2, _HOST_CONTEXT]
+    assert user32.thread_context == _HOST_CONTEXT
+
+
+def test_screenshot_restores_the_thread_dpi_context_when_the_blit_fails(
+        make_backend):
+    backend, user32, gdi32 = make_backend()
+    gdi32.bitblt_returns = 0
+    with pytest.raises(RuntimeError, match="BitBlt failed"):
+        _capture(backend, 0, 0, 8, 6)
+    assert user32.thread_context == _HOST_CONTEXT
+    assert user32.live_dcs == set(), "the screen DC leaked on the error path"
+
+
+def test_screenshot_restores_the_thread_dpi_context_when_getdc_fails(
+        make_backend):
+    backend, user32, _ = make_backend()
+    user32.get_dc_returns = 0
+    with pytest.raises(RuntimeError, match="GetDC"):
+        _capture(backend, 0, 0, 8, 6)
+    assert user32.thread_context == _HOST_CONTEXT
+
+
+def test_blit_error_reports_the_code_from_before_releasedc(make_backend):
+    """ReleaseDC runs through the same use_last_error handle and clobbers it."""
+    backend, _, gdi32 = make_backend()
+    gdi32.bitblt_returns = 0
+    with pytest.raises(RuntimeError, match=r"GetLastError=5\b"):
+        _capture(backend, 0, 0, 8, 6)
+
+
+def test_screenshot_falls_back_when_the_dpi_api_is_missing(make_backend):
+    """No export means no crash — the pre-fix behaviour, not an error."""
+    backend, user32, _ = make_backend(dpi_api=False)
+    img = _capture(backend, 3, 2, 8, 6)
+    assert user32.context_log == []
+    assert numpy.array_equal(img, user32.virtual_screen[2:8, 3:11])
+
+
+# -------- the screen DC --------
+
+def test_the_screen_dc_is_acquired_inside_the_awareness_scope(make_backend):
+    """A DC acquired before the switch would blit the virtualized desktop."""
+    backend, _, gdi32 = make_backend()
+    _capture(backend, 0, 0, 8, 6)
+    blit, = gdi32.blits
+    assert blit["src_aware"] is True
+    assert blit["thread_aware"] is True
+
+
+def test_construction_acquires_its_screen_dc_inside_the_scope(make_backend):
+    _, user32, _ = make_backend()
+    init_dc, = list(user32.dc_awareness)
+    assert user32.dc_awareness[init_dc] is True
+
+
+def test_construction_does_not_retain_a_screen_dc(make_backend):
+    """The memory DC outlives the screen DC it was made compatible with."""
+    backend, user32, _ = make_backend()
+    assert user32.live_dcs == set()
+    assert len(user32.released_dcs) == 1
+    assert not hasattr(backend, "_screen_dc")
+
+
+def test_every_capture_acquires_and_releases_its_own_screen_dc(make_backend):
+    backend, user32, _ = make_backend()
+    for _ in range(3):
+        _capture(backend, 0, 0, 8, 6)
+    # one from __init__ plus one per capture, all handed back
+    assert len(user32.released_dcs) == 4
+    assert len(set(user32.released_dcs)) == 4
+    assert user32.live_dcs == set()
+
+
+# -------- coordinates --------
+
+_REGIONS = [
+    (0, 0, 64, 48),      # the whole physical panel
+    (0, 0, 8, 6),
+    (7, 5, 11, 9),       # odd offset and size
+    (33, 25, 4, 4),      # past the 32x24 a DPI-unaware caller could reach
+    (63, 47, 1, 1),      # the bottom-right physical pixel
+]
+
+
+@pytest.mark.parametrize("x, y, w, h", _REGIONS)
+def test_coordinates_reach_bitblt_as_device_pixels(make_backend, x, y, w, h):
+    """No scale factor anywhere: the region is passed through untouched."""
+    backend, _, gdi32 = make_backend()
+    _capture(backend, x, y, w, h)
+    blit, = gdi32.blits
+    assert (blit["sx"], blit["sy"]) == (x, y)
+    assert (blit["w"], blit["h"]) == (w, h)
+    assert (blit["dx"], blit["dy"]) == (0, 0)
+
+
+@pytest.mark.parametrize("x, y, w, h", _REGIONS)
+def test_capture_matches_the_physical_backing_store(make_backend, x, y, w, h):
+    backend, user32, _ = make_backend()
+    img = _capture(backend, x, y, w, h)
+    assert img.shape == (h, w, 4)
+    assert numpy.array_equal(img, user32.screen[y:y + h, x:x + w])
+
+
+def test_capture_is_unchanged_at_a_100_percent_scale(make_backend):
+    """The case CI and most desktops see; the fix must be a no-op there."""
+    backend, user32, _ = make_backend(scale=1)
+    assert backend.resolution() == PHYSICAL
+    assert numpy.array_equal(_capture(backend, 7, 5, 11, 9),
+                             user32.screen[5:14, 7:18])
+
+
+# -------- the DIBSection cache is not collateral damage --------
+
+def test_the_dibsection_is_reused_for_a_repeated_size(make_backend):
+    backend, _, gdi32 = make_backend()
+    for _ in range(3):
+        _capture(backend, 0, 0, 8, 6)
+    assert len(gdi32.created_bitmaps) == 1
+    assert gdi32.deleted_bitmaps == []
+
+
+def test_a_new_size_replaces_the_dibsection(make_backend):
+    backend, _, gdi32 = make_backend()
+    _capture(backend, 0, 0, 8, 6)
+    _capture(backend, 0, 0, 12, 10)
+    assert len(gdi32.created_bitmaps) == 2
+    assert gdi32.deleted_bitmaps == gdi32.created_bitmaps[:1]
+
+
+# -------- the context manager itself --------
+
+def test_thread_dpi_aware_reports_whether_awareness_took():
+    user32 = _FakeUser32()
+    with _thread_dpi_aware(user32) as aware:
+        assert aware is True
+        assert user32.aware()
+    assert user32.thread_context == _HOST_CONTEXT
+
+
+def test_thread_dpi_aware_is_a_no_op_without_the_export():
+    user32 = _FakeUser32(dpi_api=False)
+    with _thread_dpi_aware(user32) as aware:
+        assert aware is False
+    assert user32.thread_context == _HOST_CONTEXT
+    assert user32.context_log == []
+
+
+def test_thread_dpi_aware_does_not_restore_a_rejected_context():
+    """NULL means nothing was changed, so there is nothing to put back."""
+    user32 = _FakeUser32()
+    user32.SetThreadDpiAwarenessContext = lambda context: None
+    with _thread_dpi_aware(user32) as aware:
+        assert aware is False
+    assert user32.thread_context == _HOST_CONTEXT
+
+
+def test_thread_dpi_aware_restores_on_an_exception():
+    user32 = _FakeUser32()
+    with pytest.raises(ZeroDivisionError):
+        with _thread_dpi_aware(user32):
+            1 / 0
+    assert user32.thread_context == _HOST_CONTEXT
+
+
+# -------- the fakes themselves --------
+
+def test_an_out_of_range_blit_is_not_silently_zero_padded():
+    """Guards the fake: numpy slicing would have clipped these away."""
+    user32 = _FakeUser32()
+    gdi32 = _FakeGdi32(user32)
+    hdc = user32.GetDC(None)
+    gdi32.CreateDIBSection(0x2000, _bmi(10, 10), 0,
+                           ctypes.byref(ctypes.c_void_p()), None, 0)
+    gdi32.selected = gdi32.created_bitmaps[-1]
+    with pytest.raises(AssertionError, match="outside the"):
+        gdi32.BitBlt(0x2000, 0, 0, 10, 10, hdc, 60, 44, 0)
+
+
+def test_a_stale_screen_dc_would_serve_the_virtualized_desktop():
+    """Guards the fake that makes the cached-DC regression detectable."""
+    user32 = _FakeUser32()
+    gdi32 = _FakeGdi32(user32)
+    stale = user32.GetDC(None)               # acquired while unaware
+    with _thread_dpi_aware(user32):
+        assert user32.aware()
+        gdi32.CreateDIBSection(0x2000, _bmi(8, 6), 0,
+                               ctypes.byref(ctypes.c_void_p()), None, 0)
+        gdi32.selected = gdi32.created_bitmaps[-1]
+        gdi32.BitBlt(0x2000, 0, 0, 8, 6, stale, 0, 0, 0)
+    buf, _, _ = gdi32.buffers[gdi32.selected]
+    got = numpy.frombuffer(buf, numpy.uint8).reshape(6, 8, 4)
+    assert numpy.array_equal(got, user32.virtual_screen[0:6, 0:8])
+    assert not numpy.array_equal(got, user32.screen[0:6, 0:8])


### PR DESCRIPTION
Closes #39.

`base.py` promises **device pixels**, but Win32 only tells the truth to a DPI-aware
caller: `GetSystemMetrics` is virtualized to 96 DPI for a DPI-unaware thread, and
`BitBlt` against the desktop reads the virtualized surface. CPython's manifest
declares no awareness, so what fastgrab reported depended on whichever host
application happened to embed it.

## What this does

* Adds `_thread_dpi_aware()`, a context manager that sets
  `DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2` on the **calling thread only** and
  restores the previous context in a `finally`. Process-wide
  `SetProcessDpiAwarenessContext` is deliberately not used — it is a one-shot,
  irreversible property that would re-scale the UI of any application that merely
  imported fastgrab.
* Wraps the metrics query, the screen-DC acquisition and the blit.
* Probes `SetThreadDpiAwarenessContext` with `getattr`, so Windows older than
  10 1607 degrades to the previous behaviour instead of crashing.
* **Drops the cached screen DC.** A DC's virtualization is fixed at acquisition,
  so a DC cached at construction time on an unaware thread would keep reading the
  virtualized desktop no matter which context is in force when `BitBlt` runs. The
  caching that actually makes this backend fast — the DIBSection and its memory DC
  — is untouched; a `GetDC`/`ReleaseDC` pair is microseconds against a
  millisecond-scale blit.
* Incidental fix: `ctypes.get_last_error()` was read *after* `ReleaseDC`, which
  goes through the same `use_last_error=True` handle and clobbers it.

No new runtime dependencies — `contextlib` is the only added import.

## Tests

`tests/test_windows_backend.py`, 32 tests, all executing on Linux (`ctypes.wintypes`
is stubbed in). The fakes model the OS as state rather than recording calls: the
fake thread context really does virtualize `GetSystemMetrics`, a screen DC remembers
the awareness it was acquired under, and `ReleaseDC` clobbers a shared last-error slot.

`docker compose run --rm test` → **200 passed, 10 deselected**.

Checked non-vacuous: neutering `_thread_dpi_aware` fails 15 of the 32.

## Known limits

* **Not executed on real hardware at a non-100% scale.** `windows-latest` runs at
  100%, where this change is a no-op by construction. That
  `SetThreadDpiAwarenessContext(-4)` flips `GetSystemMetrics` to physical pixels is
  documented Win32 behaviour, but it is *modelled* here, not verified.
* **Primary monitor only**, unchanged. `resolution()` stays on `SM_CXSCREEN` rather
  than the `SM_CXVIRTUALSCREEN` family, because this backend blits from the desktop
  DC whose origin is the primary monitor's top-left; reporting the virtual screen
  would hand callers a bbox space `screenshot()` does not index. That is the future
  `Screenshot(display=N)` feature, not a DPI fix.
* `base.py`'s known-gap bullet is narrowed rather than deleted — still honest about
  older Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLmJd7aNG8CRS7EQ9waLqD
