### PR TITLE
wlr: convert sub-region bboxes to logical coordinates

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         xdotool \
         procps \
         cage \
+        wlr-randr \
         libwayland-client0 \
         libwayland-dev \
         wayland-protocols \

--- a/fastgrab/backends/base.py
+++ b/fastgrab/backends/base.py
@@ -25,13 +25,15 @@ backend honours it yet. Known gaps, so this docstring is not read as a
 promise the code keeps:
 
 * ``x11`` and ``macos`` honour it.
-* ``wlr`` honours it for full-output capture. Sub-region capture takes
-  the region in *logical* coordinates (a ``wlr-screencopy`` protocol
-  requirement), which matches device pixels only on an output that is
-  both unscaled and untransformed — wlroots applies the transform
-  before the scale, so a rotation transposes the frame even at scale 1.
-  The backend refuses a sub-region request on any other output rather
-  than returning the wrong one. See issue #38.
+* ``wlr`` honours it. ``wlr-screencopy`` takes a sub-region in *logical*
+  coordinates, so the backend converts the device-pixel bbox through
+  the output's ``xdg_output`` logical size, rounds the region outward,
+  and crops the returned frame back to the exact bbox. One gap is left:
+  wlroots applies the output transform *before* the scale, so on a
+  rotated or flipped output the region lands on a transposed backing
+  store — the backend refuses a sub-region request there rather than
+  returning the wrong one. Full-output capture is unaffected either
+  way. See issue #38.
 * ``windows`` reports and captures in whatever DPI context the host
   process happens to have. Windows virtualizes screen metrics for
   DPI-unaware threads and ``BitBlt`` takes logical units, and neither

--- a/fastgrab/backends/wlr.py
+++ b/fastgrab/backends/wlr.py
@@ -8,6 +8,14 @@ intended fallback.
 V1 captures from a single output. Selection order:
 ``$FASTGRAB_OUTPUT`` (if set, matches output ``name``) → first output
 advertised. Multi-monitor composition is out of scope for this version.
+
+``capture_output_region`` takes its region in **output logical
+coordinates**, while a fastgrab bbox is device pixels and
+:meth:`WlrBackend.resolution` reports the ``wl_output`` mode size. Those
+agree only on an unscaled output. The gap is closed by tracking the
+output's logical geometry through ``zxdg_output_manager_v1`` and
+converting at this boundary — see :func:`_plan_region` for the
+conversion and exactly what it is allowed to assume.
 """
 import mmap
 import os
@@ -17,6 +25,14 @@ import numpy as np
 
 from pywayland.client import Display
 from pywayland.protocol.wayland import WlOutput, WlShm
+
+try:
+    from pywayland.protocol.xdg_output_unstable_v1 import ZxdgOutputManagerV1
+except ImportError:  # pragma: no cover — older than the pywayland the extra pins
+    # Without xdg_output the output's logical size is unknowable, and
+    # sub-region capture degrades to a full-output capture plus a crop.
+    # See WlrBackend._subregion_plan.
+    ZxdgOutputManagerV1 = None
 
 from .base import BaseBackend
 from .protocols.wlr_screencopy_unstable_v1 import ZwlrScreencopyManagerV1
@@ -30,11 +46,16 @@ _WL_SHM_FORMAT_XRGB8888 = 1
 
 _FRAME_VERSION = 3
 
+# zxdg_output_manager_v1 is at version 3; logical_position and
+# logical_size have been there since version 1, so binding low is safe.
+_XDG_OUTPUT_VERSION = 3
+
 
 class _OutputState:
     """Mutable accumulator for a single ``wl_output``'s geometry events."""
     __slots__ = ("proxy", "name", "mode_w", "mode_h", "scale", "transform",
-                 "done")
+                 "logical_x", "logical_y", "logical_w", "logical_h",
+                 "xdg", "done")
 
     def __init__(self, proxy):
         self.proxy = proxy
@@ -45,6 +66,14 @@ class _OutputState:
         # WL_OUTPUT_TRANSFORM_NORMAL; anything else rotates or flips the
         # logical coordinate space relative to the backing store.
         self.transform = 0
+        # xdg_output's logical geometry, the unit capture_output_region
+        # speaks. 0 means "never told": a compositor need not advertise
+        # zxdg_output_manager_v1 at all.
+        self.logical_x = 0
+        self.logical_y = 0
+        self.logical_w = 0
+        self.logical_h = 0
+        self.xdg = None
         self.done = False
 
 
@@ -62,6 +91,103 @@ class _FrameState:
         self.flags = 0
         self.ready = False
         self.failed = False
+
+
+class _RegionPlan:
+    """How to ask for a device-pixel bbox, and what to do with the answer.
+
+    ``region`` is the ``(x, y, width, height)`` to hand to
+    ``capture_output_region`` in output *logical* coordinates, or
+    ``None`` to capture the whole output instead. ``crop_x``/``crop_y``
+    say where the requested bbox starts inside the frame that comes
+    back, in device pixels. ``exp_w``/``exp_h`` is the device-pixel frame
+    size the mapping predicts; it is checked against what the compositor
+    actually returned before a byte is copied, which is what makes the
+    rest of the plan trustworthy rather than merely plausible.
+    """
+    __slots__ = ("region", "crop_x", "crop_y", "exp_w", "exp_h")
+
+    def __init__(self, region, crop_x, crop_y, exp_w, exp_h):
+        self.region = region
+        self.crop_x = crop_x
+        self.crop_y = crop_y
+        self.exp_w = exp_w
+        self.exp_h = exp_h
+
+
+def _ceil_div(numerator, denominator):
+    """Integer ceiling division, for non-negative operands."""
+    return -(-numerator // denominator)
+
+
+def _uniform_integer_scale(mode_w, mode_h, logical_w, logical_h):
+    """Return ``k`` when ``device == logical * k`` exactly on both axes.
+
+    ``None`` when the logical geometry is unknown, or when the ratio is
+    not one and the same whole number on both axes — a fractionally
+    scaled output, or one whose logical size the compositor rounded.
+    """
+    if logical_w <= 0 or logical_h <= 0:
+        return None
+    if mode_w % logical_w or mode_h % logical_h:
+        return None
+    scale = mode_w // logical_w
+    if scale < 1 or mode_h // logical_h != scale:
+        return None
+    return scale
+
+
+def _plan_region(x, y, w, h, mode_w, mode_h, logical_w, logical_h):
+    """Map a device-pixel bbox onto a logical region plus a crop.
+
+    Two cases, and the split is about what can be *proved*, not about
+    what is likely.
+
+    **Exact integer scale.** wlroots turns a region request into a
+    device-pixel box by multiplying each component by the output scale
+    and truncating (``buffer_box.x *= output->scale``, an ``int``
+    left-hand side and a ``float`` right-hand side). Truncation is a
+    no-op for a whole-number scale, so the frame that comes back starts
+    at exactly ``logical_origin * k``: floor the requested origin into
+    logical units, ceil the far edge so every requested pixel stays
+    covered, and crop the surplus off the returned frame.
+
+    That ``k`` is derived, not observed. ``wl_output.scale`` is a
+    ``ceil()``'d integer, and xdg_output's logical size is itself
+    ``trunc(mode / scale)``, which only bounds the true scale ``s`` from
+    above (``s <= mode / logical == k``). The frame-size check in
+    :meth:`WlrBackend.screenshot` closes the gap: the compositor returns
+    ``trunc(lw * s)`` where this plan predicts ``lw * k``, and those
+    agree only when ``s >= k``. A matching size therefore *proves*
+    ``s == k``, and with it the origin. An output at, say, 1.999 on a
+    mode whose logical size happens to divide evenly returns a short
+    frame and is rejected rather than silently mis-cropped.
+
+    **Anything else** — a fractional scale, or axes that disagree. There
+    the device origin of a region frame is ``trunc(lx * s)`` for a float
+    ``s`` that cannot be recovered exactly from the integers the
+    protocol hands us, so any origin but zero risks being off by a
+    pixel. Rather than guess, capture the whole output — which is
+    ``mode_w x mode_h`` device pixels by definition, with no scale
+    arithmetic involved — and crop the bbox out of it. Correct, at the
+    cost of copying the whole output for a small bbox: the same trade
+    this backend used to ask callers to make by hand.
+    """
+    scale = _uniform_integer_scale(mode_w, mode_h, logical_w, logical_h)
+    if scale is None:
+        return _RegionPlan(None, x, y, mode_w, mode_h)
+
+    lx = x // scale
+    ly = y // scale
+    lw = _ceil_div(x + w, scale) - lx
+    lh = _ceil_div(y + h, scale) - ly
+    return _RegionPlan(
+        (lx, ly, lw, lh),
+        crop_x=x - lx * scale,
+        crop_y=y - ly * scale,
+        exp_w=lw * scale,
+        exp_h=lh * scale,
+    )
 
 
 # The wayland connection + globals are shared across all WlrBackend
@@ -99,6 +225,7 @@ class WlrBackend(BaseBackend):
         outputs = []
         shm = [None]
         screencopy = [None]
+        xdg_output_manager = [None]
 
         def _on_global(registry, name, interface, version):
             if interface == "wl_output":
@@ -127,11 +254,26 @@ class WlrBackend(BaseBackend):
                 screencopy[0] = registry.bind(
                     name, ZwlrScreencopyManagerV1, min(version, _FRAME_VERSION)
                 )
+            elif (interface == "zxdg_output_manager_v1"
+                    and ZxdgOutputManagerV1 is not None):
+                xdg_output_manager[0] = registry.bind(
+                    name, ZxdgOutputManagerV1,
+                    min(version, _XDG_OUTPUT_VERSION),
+                )
 
         registry = display.get_registry()
         registry.dispatcher["global"] = _on_global
         display.roundtrip()
-        display.roundtrip()  # let wl_output mode/name/done events settle
+
+        # xdg_output has to be a second pass: get_xdg_output needs the
+        # manager *and* the wl_output, and the registry is free to
+        # announce them in either order.
+        if xdg_output_manager[0] is not None:
+            for state in outputs:
+                WlrBackend._bind_xdg_output(xdg_output_manager[0], state)
+
+        display.roundtrip()
+        display.roundtrip()  # let mode/name/done + logical_size settle
 
         if screencopy[0] is None:
             raise RuntimeError(
@@ -146,6 +288,19 @@ class WlrBackend(BaseBackend):
         return display, shm[0], screencopy[0], outputs
 
     # -------- output state event handlers --------
+
+    @staticmethod
+    def _bind_xdg_output(manager, state):
+        """Create an ``xdg_output`` for ``state`` and wire up its events."""
+        xdg = manager.get_xdg_output(state.proxy)
+        xdg.dispatcher["logical_position"] = lambda o, lx, ly, s=state: (
+            WlrBackend._on_xdg_logical_position(s, lx, ly)
+        )
+        xdg.dispatcher["logical_size"] = lambda o, lw, lh, s=state: (
+            WlrBackend._on_xdg_logical_size(s, lw, lh)
+        )
+        state.xdg = xdg
+        return xdg
 
     @staticmethod
     def _on_output_mode(state, flags, width, height):
@@ -170,6 +325,16 @@ class WlrBackend(BaseBackend):
     def _on_output_done(state):
         state.done = True
 
+    @staticmethod
+    def _on_xdg_logical_position(state, x, y):
+        state.logical_x = x
+        state.logical_y = y
+
+    @staticmethod
+    def _on_xdg_logical_size(state, width, height):
+        state.logical_w = width
+        state.logical_h = height
+
     def _select_output(self):
         wanted = os.environ.get("FASTGRAB_OUTPUT")
         if wanted:
@@ -193,12 +358,14 @@ class WlrBackend(BaseBackend):
         fields latched from events at connect time, so a mode change is
         invisible until the display is dispatched again. Two round trips
         let pending ``mode``/``name``/``done`` events settle, matching
-        what ``_connect_singleton`` does.
+        what ``_connect_singleton`` does. The ``xdg_output`` objects are
+        long-lived, so a scale change re-sends ``logical_size`` over the
+        same round trips.
 
-        Mode changes and a different ``FASTGRAB_OUTPUT`` choice among the
-        already-bound outputs are picked up. An output that has since
-        been unplugged is *not*: that needs registry ``global_remove``
-        tracking, which this backend does not do.
+        Mode changes, scale changes and a different ``FASTGRAB_OUTPUT``
+        choice among the already-bound outputs are picked up. An output
+        that has since been unplugged is *not*: that needs registry
+        ``global_remove`` tracking, which this backend does not do.
         """
         self._display.roundtrip()
         self._display.roundtrip()
@@ -210,35 +377,62 @@ class WlrBackend(BaseBackend):
     def bytes_per_pixel(self):
         return 4
 
+    def _subregion_plan(self, x, y, w, h):
+        """Plan a sub-region capture of the device-pixel bbox ``x, y, w, h``.
+
+        Raises :class:`NotImplementedError` for the one mapping this
+        backend still refuses outright: a rotated or flipped output.
+        wlroots applies the output transform *before* the scale, so a
+        region on a transformed output lands on a transposed backing
+        store — and nothing here models that, so guessing would be worse
+        than refusing.
+        """
+        out = self._output
+        if out.transform != 0:
+            raise NotImplementedError(
+                "sub-region capture is not supported on output {!r} "
+                "(transform {}): wlr-screencopy takes the region in "
+                "logical coordinates and wlroots applies the output "
+                "transform before the scale, so on a rotated or flipped "
+                "output the region lands on a transposed backing store — "
+                "a 20x10 request comes back 10x20. fastgrab does not "
+                "model output transforms. Capture the full output and "
+                "slice the returned array instead."
+                .format(out.name, out.transform)
+            )
+
+        logical_w = out.logical_w or 0
+        logical_h = out.logical_h or 0
+        if logical_w > 0 and logical_h > 0:
+            return _plan_region(x, y, w, h, out.mode_w, out.mode_h,
+                                logical_w, logical_h)
+
+        # No xdg_output: the compositor never told us the logical size.
+        if out.scale != 1:
+            # wl_output.scale is ceil() of the real scale, an upper bound
+            # and nothing more — not enough to place a region. Take the
+            # whole output, whose size needs no scale arithmetic, and crop.
+            return _RegionPlan(None, x, y, out.mode_w, out.mode_h)
+
+        # Scale 1 and no logical size: assume the identity mapping and
+        # let the frame-size check adjudicate. It has to, because ceil()
+        # collapses every scale in (0, 1] onto the same reported 1.
+        return _RegionPlan((x, y, w, h), 0, 0, w, h)
+
     def screenshot(self, x, y, img):
         h, w, _ = img.shape
         full_w, full_h = self.resolution()
         if x == 0 and y == 0 and w == full_w and h == full_h:
+            # The whole output: no region, so no logical conversion at all.
+            plan = _RegionPlan(None, 0, 0, w, h)
+        else:
+            plan = self._subregion_plan(x, y, w, h)
+
+        if plan.region is None:
             frame = self._screencopy.capture_output(0, self._output.proxy)
         else:
-            # capture_output_region takes the region in *logical*
-            # coordinates -- the protocol XML says so explicitly -- while
-            # a fastgrab bbox is device pixels. The identity mapping
-            # between them needs BOTH an unscaled and an untransformed
-            # output: wlroots applies the output transform before the
-            # scale, so a 90-degree rotation transposes the frame even at
-            # scale 1 (a 20x10 request comes back 10x20), and a scale of
-            # 2 doubles it. Refuse anything but the identity case rather
-            # than hand back the wrong region; full-output capture goes
-            # through capture_output above and is unaffected.
-            if self._output.scale != 1 or self._output.transform != 0:
-                raise NotImplementedError(
-                    "sub-region capture is not supported on output {!r} "
-                    "(scale {}, transform {}): wlr-screencopy takes the "
-                    "region in logical coordinates while fastgrab bboxes "
-                    "are device pixels, and the two agree only on an "
-                    "unscaled, untransformed output. Capture the full "
-                    "output and slice the returned array instead."
-                    .format(self._output.name, self._output.scale,
-                            self._output.transform)
-                )
             frame = self._screencopy.capture_output_region(
-                0, self._output.proxy, x, y, w, h
+                0, self._output.proxy, *plan.region
             )
 
         state = _FrameState()
@@ -266,24 +460,31 @@ class WlrBackend(BaseBackend):
             frame.destroy()
             raise RuntimeError("wlr-screencopy frame failed before buffer info")
 
-        # The up-front guard cannot catch every non-identity mapping:
-        # wl_output.scale is an *integer* event and wlroots reports
-        # ceil() of the real scale, so an output at 0.75 announces scale
-        # 1 and looks like identity. The compositor then returns a
-        # smaller frame, and `img[:] = arr` would broadcast it over the
-        # destination instead of failing -- a 1x1 frame silently filling
-        # a 2x2 request. Checking what actually came back catches that,
-        # and any other cause, before a single byte is copied.
-        if state.w != w or state.h != h:
+        # Check the size the compositor actually returned rather than
+        # trusting the scale it announced. wl_output.scale is an integer
+        # event reported as ceil() of the real scale, so an output at
+        # 0.75 announces 1 and looks like identity; xdg_output's logical
+        # size only bounds the real scale from above. This check is what
+        # turns _plan_region's derived mapping into a proved one — and
+        # without it `img[:] = arr` would *broadcast* a too-small frame
+        # over the destination instead of failing, filling a 2x2 request
+        # from a single pixel.
+        if state.w != plan.exp_w or state.h != plan.exp_h:
             frame.destroy()
             raise NotImplementedError(
-                "compositor returned a {}x{} frame for a {}x{} request on "
-                "output {!r} (reported scale {}, transform {}): the region "
-                "is interpreted in logical coordinates, and wl_output.scale "
-                "is an integer, so a fractionally scaled output reports 1 "
-                "and cannot be detected up front. Capture the full output "
-                "and slice the returned array instead."
-                .format(state.w, state.h, w, h, self._output.name,
+                "compositor returned a {}x{} frame where the region "
+                "mapping predicted {}x{} device pixels, for a {}x{} "
+                "capture at ({}, {}) on output {!r} (mode {}x{}, logical "
+                "{}x{}, wl_output.scale {}, transform {}). The region is "
+                "interpreted in logical coordinates, and wl_output.scale "
+                "is an integer reported as ceil() of the real scale, so a "
+                "fractionally scaled output cannot always be detected up "
+                "front. Capture the full output and slice the returned "
+                "array instead."
+                .format(state.w, state.h, plan.exp_w, plan.exp_h, w, h,
+                        x, y, self._output.name,
+                        self._output.mode_w, self._output.mode_h,
+                        self._output.logical_w, self._output.logical_h,
                         self._output.scale, self._output.transform)
             )
 
@@ -296,15 +497,23 @@ class WlrBackend(BaseBackend):
             frame.destroy()
             raise RuntimeError("wlr-screencopy frame copy failed")
 
-        # Memcpy from mmap into the caller's ndarray, accounting for stride.
+        # Memcpy from mmap into the caller's ndarray, accounting for
+        # stride. The width and stride from the buffer event drive this,
+        # never the requested size: the frame is legitimately bigger than
+        # the bbox whenever the logical region had to be rounded outward,
+        # or the whole output was taken to crop out of.
         frame_bytes = bytes(mm[: state.stride * state.h])
         arr = np.frombuffer(frame_bytes, dtype="uint8").reshape(
             state.h, state.stride
         )[:, : state.w * 4].reshape(state.h, state.w, 4)
         if state.flags & 0x1:  # Y_INVERT
+            # Flip before cropping — the flag describes the frame, so the
+            # crop offsets only count from the top left once it is upright.
             arr = np.flipud(arr)
-        # Caller's ndarray was sized (h, w, 4) by the wrapper; copy in.
-        img[:] = arr
+        # Caller's ndarray was sized (h, w, 4) by the wrapper; copy the
+        # requested bbox out of the frame. The slice is exact, so a
+        # mismatch raises instead of broadcasting.
+        img[:] = arr[plan.crop_y:plan.crop_y + h, plan.crop_x:plan.crop_x + w]
 
         frame.destroy()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -137,7 +137,12 @@ def paint_wayland():
     cs.settimeout(5.0)
 
     def _paint(color: str) -> None:
-        cs.sendall(("paint " + color + "\n").encode())
+        # "blocks" is the painter's coordinate-encoding pattern; anything
+        # else is a solid #RRGGBB. A flat color cannot distinguish a
+        # correctly placed sub-region capture from a displaced one, which
+        # is what the scale tests need to check.
+        command = "blocks" if color == "blocks" else "paint " + color
+        cs.sendall((command + "\n").encode())
         # Read until newline (the painter responds 'ok\n' or 'err: ...\n').
         buf = b""
         while b"\n" not in buf:
@@ -157,5 +162,78 @@ def paint_wayland():
 
     try:
         cs.close()
+    except Exception:
+        pass
+
+
+def _wlr_randr(*args):
+    """Run ``wlr-randr`` against the current Wayland display."""
+    return subprocess.run(
+        ["wlr-randr", *args],
+        check=True, capture_output=True, text=True,
+    )
+
+
+def _wlr_first_output_name():
+    """The name of the first output ``wlr-randr`` lists (cage has one)."""
+    for line in _wlr_randr().stdout.splitlines():
+        if line and not line[0].isspace():
+            return line.split()[0]
+    return None
+
+
+def _refresh_wlr_output_state():
+    """Round-trip the shared wlr connection so latched geometry updates.
+
+    ``WlrBackend`` keeps one connection and one set of ``_OutputState``
+    objects per process, and reads them without querying the compositor.
+    A scale change is therefore invisible — to every ``Screenshot``
+    already built *and* to every one built afterwards — until something
+    dispatches. Doing it here rather than in each test keeps a test that
+    changed the scale from leaving a stale reading behind for the next
+    one.
+    """
+    from fastgrab.backends.wlr import WlrBackend
+
+    WlrBackend().refresh()
+
+
+@pytest.fixture
+def wlr_output_scale():
+    """Set the wlroots output scale for the duration of one test.
+
+    cage's headless output comes up at scale 1 and neither cage nor the
+    wlroots headless backend takes a scale option or environment
+    variable. cage does implement ``zwlr_output_manager_v1`` though, so
+    ``wlr-randr`` can drive the scale live — which is the only way to
+    reach the scaled sub-region path of the wlr backend under
+    ``docker compose run --rm test-wayland``.
+
+    Yields ``set_scale(2)``. The scale is put back to 1 on teardown,
+    and the backend's latched output state is refreshed both times so
+    neither this test nor the next one reads a stale logical size.
+    """
+    if not _wayland_available():
+        pytest.skip("wlr_output_scale requires a working Wayland display")
+    if not shutil.which("wlr-randr"):
+        pytest.skip("wlr-randr is not installed (apt install wlr-randr)")
+
+    name = _wlr_first_output_name()
+    if not name:
+        pytest.skip("wlr-randr listed no outputs")
+
+    def _set_scale(scale) -> None:
+        _wlr_randr("--output", name, "--scale", str(scale))
+        # The compositor reconfigures the kiosk client, which redraws at
+        # the new size; give both a moment before anything is captured.
+        time.sleep(0.3)
+        _refresh_wlr_output_state()
+
+    yield _set_scale
+
+    try:
+        _wlr_randr("--output", name, "--scale", "1")
+        time.sleep(0.3)
+        _refresh_wlr_output_state()
     except Exception:
         pass

--- a/tests/test_integration_wlr.py
+++ b/tests/test_integration_wlr.py
@@ -9,11 +9,13 @@ and assert on the resulting BGRA bytes.
 These tests are tagged with the ``wayland`` marker so they're excluded
 from the X11 test run and selected explicitly via ``-m wayland``.
 """
+import time
+
 import numpy
 import pytest
 
 from fastgrab import screenshot
-from fastgrab.backends.wlr import WlrBackend
+from fastgrab.backends.wlr import WlrBackend, _uniform_integer_scale
 
 pytestmark = pytest.mark.wayland
 
@@ -105,3 +107,118 @@ def test_wlr_capture_subregion_shape(paint_wayland):
     assert (img[:, :, R] == 255).all()
     assert (img[:, :, G] == 0).all()
     assert (img[:, :, B] == 255).all()
+
+
+# -------- sub-region placement (issue #38) --------
+#
+# A solid color proves a capture has the right shape and nothing about
+# where it came from. These use the painter's `blocks` pattern, whose
+# every 8x8 block encodes its own coordinates, and compare a sub-region
+# against the same window of a full-output capture. Full-output capture
+# goes through `capture_output`, which takes no region at all, so it is
+# unaffected by the logical/device mix-up and can serve as the oracle.
+
+
+def _stable_capture(g, bbox=None, tries=20):
+    """Capture until two consecutive frames agree.
+
+    Changing the output scale makes cage reconfigure its kiosk client,
+    and a capture taken while that is still in flight sees a
+    half-updated scene. These tests compare two captures against each
+    other, so both have to be of the settled scene.
+    """
+    previous = g.capture(bbox=bbox).copy()
+    for _ in range(tries):
+        time.sleep(0.05)
+        current = g.capture(bbox=bbox).copy()
+        if numpy.array_equal(previous, current):
+            return current
+        previous = current
+    raise AssertionError("the compositor never settled on a stable frame")
+
+
+def _assert_subregion_matches_full_output(g, bbox):
+    full = _stable_capture(g)
+    assert len(numpy.unique(full[:, :, R])) > 4, (
+        "the block pattern is what makes a displaced capture detectable; "
+        "against a flat frame this assertion would pass vacuously"
+    )
+
+    x, y, w, h = bbox
+    sub = _stable_capture(g, bbox=bbox)
+    assert sub.shape == (h, w, 4)
+    numpy.testing.assert_array_equal(sub, full[y:y + h, x:x + w])
+    if (x, y) != (0, 0):
+        assert not numpy.array_equal(sub, full[0:h, 0:w]), (
+            "the pattern must differ between the bbox and the output "
+            "origin, or a capture ignoring the origin would still pass"
+        )
+
+
+_PLACEMENT_BBOXES = [
+    (0, 0, 64, 48),      # at the origin, aligned to any integer scale
+    (21, 11, 20, 10),    # odd origin — the logical region rounds outward
+    (128, 64, 100, 60),  # aligned, well away from the origin
+    (301, 177, 33, 21),  # odd origin and odd size
+]
+
+
+@pytest.mark.parametrize("bbox", _PLACEMENT_BBOXES)
+def test_wlr_subregion_comes_from_the_right_place(paint_wayland, bbox):
+    """The unscaled control for the scale-2 test below."""
+    paint_wayland("blocks")
+    _assert_subregion_matches_full_output(_grab(), bbox)
+
+
+def test_wlr_tracks_the_output_logical_size():
+    """xdg_output is what grounds the device -> logical conversion.
+
+    If ``zxdg_output_manager_v1`` were not bound, or the second-stage
+    ``get_xdg_output`` call were made before the registry had announced
+    the manager, this would silently stay 0 and every scaled sub-region
+    would quietly fall back to a full-output capture.
+    """
+    backend = WlrBackend()
+    backend.refresh()
+    output = backend._output
+    assert output.logical_w > 0 and output.logical_h > 0
+    assert (output.logical_w, output.logical_h) == backend.resolution(), (
+        "cage's headless output is unscaled, so logical == device here"
+    )
+
+
+@pytest.mark.parametrize("bbox", _PLACEMENT_BBOXES)
+@pytest.mark.parametrize("scale, exact", [
+    # cage's headless output is 1280x720. At 2 the logical size is a
+    # clean 640x360, so the backend converts the bbox and asks for a
+    # logical region. At 1.5 it is 853x480 — 1280 is not a whole
+    # multiple of 853, the scale cannot be proved, and the backend falls
+    # back to capturing the whole output and cropping.
+    (2, 2),
+    (1.5, None),
+])
+def test_wlr_subregion_comes_from_the_right_place_when_scaled(
+        paint_wayland, wlr_output_scale, scale, exact, bbox):
+    """Issue #38: the region is logical while the bbox is device pixels.
+
+    On a scale-2 output a 20x10 device request must go out as 10x5
+    logical from a halved origin. Passing the bbox through unconverted,
+    as this backend used to, asks for twice the region from twice the
+    offset — the compositor returns a 40x20 frame that does not fit the
+    destination, and such pixels as do arrive are from the wrong place.
+    """
+    wlr_output_scale(scale)
+    paint_wayland("blocks")
+
+    g = _grab()
+    output = g._backend._output
+    assert 0 < output.logical_w < g.screensize[0], (
+        "expected wlr-randr to have scaled the output, got mode {} "
+        "logical {}".format(g.screensize,
+                            (output.logical_w, output.logical_h))
+    )
+    assert _uniform_integer_scale(
+        output.mode_w, output.mode_h, output.logical_w, output.logical_h
+    ) == exact, "this parametrization is meant to exercise the other branch"
+
+    _assert_subregion_matches_full_output(g, bbox)

--- a/tests/test_wlr_backend.py
+++ b/tests/test_wlr_backend.py
@@ -1,10 +1,12 @@
 """Fake-state tests for the wlr backend that need no compositor.
 
 ``docker compose run --rm test-wayland`` exercises the real thing under
-headless ``cage``, but that session has a single unscaled, untransformed
-output and never changes mode, so the paths :meth:`WlrBackend.refresh`
-and the sub-region guard exist for are unreachable there. These drive
-the same code over hand-built output state instead.
+headless ``cage``, but that session has a single untransformed output
+and never changes mode, so the paths :meth:`WlrBackend.refresh` and the
+transform refusal exist for are unreachable there. The scale-2 mapping
+*is* reachable there (see ``tests/test_integration_wlr.py``), but only
+for the one scale ``wlr-randr`` is asked to set. These drive the same
+code over hand-built output state instead.
 """
 from types import SimpleNamespace
 
@@ -15,16 +17,33 @@ pytest.importorskip(
     "pywayland", reason="the wlr backend is behind the [wayland] extra"
 )
 
-from fastgrab.backends.wlr import WlrBackend  # noqa: E402
+from fastgrab.backends.wlr import (  # noqa: E402
+    WlrBackend, _plan_region, _uniform_integer_scale,
+)
 
 # Hand-built output state only — no compositor, no display server.
 pytestmark = pytest.mark.no_display
 
 
-def _output(name="HDMI-1", mode_w=100, mode_h=50, scale=1, transform=0):
-    """An output as ``_connect_singleton`` would have accumulated it."""
+def _output(name="HDMI-1", mode_w=100, mode_h=50, scale=1, transform=0,
+            logical_w=0, logical_h=0):
+    """An output as ``_connect_singleton`` would have accumulated it.
+
+    ``logical_w``/``logical_h`` are the ``xdg_output.logical_size`` the
+    compositor reported; 0 means it never did — a compositor need not
+    advertise ``zxdg_output_manager_v1``.
+    """
     return SimpleNamespace(proxy=object(), name=name, mode_w=mode_w,
-                           mode_h=mode_h, scale=scale, transform=transform)
+                           mode_h=mode_h, scale=scale, transform=transform,
+                           logical_x=0, logical_y=0,
+                           logical_w=logical_w, logical_h=logical_h,
+                           xdg=None)
+
+
+def _scaled_output(mode_w, mode_h, logical_w, logical_h, **kw):
+    """An output whose logical size is known, as xdg_output reports it."""
+    return _output(mode_w=mode_w, mode_h=mode_h,
+                   logical_w=logical_w, logical_h=logical_h, **kw)
 
 
 def _fake_backend(outputs, on_roundtrip=None):
@@ -79,19 +98,124 @@ def test_refresh_raises_for_an_unknown_requested_output(monkeypatch):
         backend.refresh()
 
 
-@pytest.mark.parametrize("output, why", [
-    (_output(scale=2), "a scale of 2 doubles the frame"),
-    (_output(transform=1), "a 90 degree rotation transposes it"),
-    (_output(transform=3), "270 degrees likewise"),
-    (_output(scale=2, transform=1), "both at once"),
-])
-def test_subregion_capture_is_refused_off_the_identity_mapping(output, why):
-    """The region is logical; device pixels match only at scale 1, no transform.
+# -------- the device-pixel -> logical conversion, on its own --------
 
-    wlroots applies the output transform *before* the scale, so a
-    rotation breaks the correspondence even on an unscaled output — a
-    20x10 request comes back 10x20. Refusing beats returning the wrong
-    pixels, which is what a scale-only guard would have done here.
+
+def test_uniform_integer_scale_recognises_a_whole_number_ratio():
+    assert _uniform_integer_scale(200, 100, 100, 50) == 2
+    assert _uniform_integer_scale(100, 50, 100, 50) == 1
+    assert _uniform_integer_scale(300, 150, 100, 50) == 3
+
+
+@pytest.mark.parametrize("mode, logical, why", [
+    ((1920, 1080), (1280, 720), "1.5 is not a whole number"),
+    ((1920, 1080), (1097, 617), "1.75, and the division was truncated"),
+    ((1920, 1080), (960, 1080), "the two axes disagree"),
+    ((1920, 1080), (0, 0), "the compositor never sent a logical size"),
+])
+def test_uniform_integer_scale_refuses_anything_else(mode, logical, why):
+    assert _uniform_integer_scale(*mode, *logical) is None, why
+
+
+def test_plan_region_at_scale_1_is_the_identity():
+    """An unscaled output is the case the old pass-through got right."""
+    plan = _plan_region(20, 10, 20, 10, 100, 50, 100, 50)
+    assert plan.region == (20, 10, 20, 10)
+    assert (plan.crop_x, plan.crop_y) == (0, 0)
+    assert (plan.exp_w, plan.exp_h) == (20, 10)
+
+
+def test_plan_region_at_scale_2_halves_the_request():
+    """The issue's case: a 20x10 device request is 10x5 logical.
+
+    Sending 20x10 through unchanged is what issue #38 is about — the
+    compositor reads it as logical, doubles it, and returns a 40x20
+    frame that does not fit the 20x10 destination.
+    """
+    plan = _plan_region(20, 10, 20, 10, 200, 100, 100, 50)
+    assert plan.region == (10, 5, 10, 5)
+    assert (plan.exp_w, plan.exp_h) == (20, 10)
+
+
+def test_plan_region_at_scale_2_displaces_the_origin_too():
+    """Not just the size: the origin is in logical units as well.
+
+    A bbox at device (60, 30) starts at logical (30, 15). Passing 60,30
+    straight through would capture from twice as far into the output.
+    """
+    plan = _plan_region(60, 30, 20, 10, 200, 100, 100, 50)
+    assert plan.region[:2] == (30, 15)
+    assert (plan.crop_x, plan.crop_y) == (0, 0)
+
+
+def test_plan_region_rounds_the_logical_region_outward():
+    """A bbox not aligned to the scale must still be fully covered.
+
+    Device x=21 sits inside logical column 10 (which covers device
+    21..22 at scale 2), and the far edge 41 needs logical 21. So the
+    region is 10..20 wide, i.e. 11 logical columns, and the surplus
+    device pixel on the left is cropped off afterwards.
+    """
+    plan = _plan_region(21, 11, 20, 10, 200, 100, 100, 50)
+    assert plan.region == (10, 5, 11, 6)
+    # floor(21/2) * 2 == 20, so the bbox starts one device pixel in
+    assert (plan.crop_x, plan.crop_y) == (1, 1)
+    assert (plan.exp_w, plan.exp_h) == (22, 12)
+    # the rounded-outward frame really does contain the whole bbox
+    assert plan.crop_x + 20 <= plan.exp_w
+    assert plan.crop_y + 10 <= plan.exp_h
+
+
+@pytest.mark.parametrize("x, y, w, h", [
+    (0, 0, 1, 1), (1, 1, 1, 1), (3, 7, 5, 9), (37, 41, 63, 59),
+    (0, 0, 200, 100), (199, 99, 1, 1),
+])
+@pytest.mark.parametrize("scale", [1, 2, 3, 4])
+def test_plan_region_always_covers_the_requested_bbox(x, y, w, h, scale):
+    """Whatever the alignment, the crop must land inside the frame."""
+    mode_w, mode_h = 200 * scale, 100 * scale
+    plan = _plan_region(x * scale, y * scale, w, h, mode_w, mode_h, 200, 100)
+    assert plan.crop_x >= 0 and plan.crop_y >= 0
+    assert plan.crop_x + w <= plan.exp_w
+    assert plan.crop_y + h <= plan.exp_h
+
+
+def test_plan_region_at_a_fractional_scale_takes_the_whole_output():
+    """1.5 cannot place a region exactly, so capture everything and crop.
+
+    wlroots computes the frame's device origin as ``trunc(lx * scale)``
+    with a float scale we can only bound from above, so any origin but
+    zero could be off by a pixel. A full-output capture is
+    ``mode_w x mode_h`` by definition — no scale arithmetic, no guess.
+    """
+    plan = _plan_region(60, 30, 20, 10, 1920, 1080, 1280, 720)
+    assert plan.region is None, "None means capture_output, not a region"
+    assert (plan.crop_x, plan.crop_y) == (60, 30)
+    assert (plan.exp_w, plan.exp_h) == (1920, 1080)
+
+
+def test_plan_region_takes_the_whole_output_when_the_axes_disagree():
+    plan = _plan_region(10, 10, 5, 5, 1920, 1080, 960, 1080)
+    assert plan.region is None
+    assert (plan.crop_x, plan.crop_y) == (10, 10)
+
+
+# -------- what the backend refuses, and what it no longer refuses --------
+
+
+@pytest.mark.parametrize("output, why", [
+    (_output(transform=1), "a 90 degree rotation transposes the frame"),
+    (_output(transform=3), "270 degrees likewise"),
+    (_output(transform=4), "a flip reorders it"),
+    (_scaled_output(200, 100, 100, 50, scale=2, transform=1), "both at once"),
+])
+def test_subregion_capture_is_refused_on_a_transformed_output(output, why):
+    """wlroots applies the transform *before* the scale.
+
+    So a rotation breaks the device/logical correspondence even on an
+    unscaled output — a 20x10 request comes back 10x20 — and this
+    backend does not model transforms. Refusing beats returning a
+    region taken from a transposed backing store.
     """
     backend, _ = _fake_backend([output])
     with pytest.raises(NotImplementedError, match="logical coordinates"):
@@ -99,12 +223,20 @@ def test_subregion_capture_is_refused_off_the_identity_mapping(output, why):
 
 
 def test_subregion_capture_is_allowed_on_an_identity_output():
-    """The guard must not block the case that actually works."""
+    """The guard must not block the case that always worked."""
     backend, _ = _fake_backend([_output()])
     # No _screencopy on the fake, so reaching the capture call raises
     # AttributeError — which proves the guard did not fire.
     with pytest.raises(AttributeError):
         backend.screenshot(0, 0, numpy.zeros((10, 20, 4), numpy.uint8))
+
+
+def test_subregion_capture_is_no_longer_refused_at_scale_2():
+    """The refusal issue #38 tracks is lifted for a known integer scale."""
+    output = _scaled_output(200, 100, 100, 50, scale=2)
+    backend, _ = _fake_backend([output])
+    with pytest.raises(AttributeError):
+        backend.screenshot(20, 10, numpy.zeros((10, 20, 4), numpy.uint8))
 
 
 @pytest.mark.parametrize("output", [
@@ -120,15 +252,26 @@ def test_full_output_capture_is_never_blocked_by_the_guard(output):
 class _FakeFrame:
     """A zwlr_screencopy_frame_v1 that reports a fixed buffer size."""
 
-    def __init__(self, w, h):
+    def __init__(self, w, h, pixels=None, flags=0):
         self.dispatcher = {}
         self.w, self.h = w, h
+        self.pixels = pixels
+        self.flags = flags
         self.destroyed = False
+        self.copied = False
 
     def deliver_buffer(self):
         # wl_shm ARGB8888 is format 0.
         self.dispatcher["buffer"](self, 0, self.w, self.h, self.w * 4)
+        if self.flags:
+            self.dispatcher["flags"](self, self.flags)
         self.dispatcher["buffer_done"](self)
+
+    def deliver_ready(self):
+        self.dispatcher["ready"](self, 0, 0, 0)
+
+    def copy(self, wl_buffer):
+        self.copied = True
 
     def destroy(self):
         self.destroyed = True
@@ -180,3 +323,163 @@ def test_matching_frame_size_passes_the_check():
     # allowed this through.
     with pytest.raises(AttributeError):
         backend.screenshot(0, 0, numpy.zeros((2, 2, 4), numpy.uint8))
+
+
+def test_a_short_frame_on_the_scale_2_path_is_refused():
+    """The size check is what *proves* the derived integer scale.
+
+    xdg_output's logical size only bounds the real scale from above, so
+    an output at 1.999 on a mode whose logical size happens to divide
+    evenly would look like a clean scale of 2. It returns a frame one
+    pixel short of the prediction, and that is the tell.
+    """
+    output = _scaled_output(200, 100, 100, 50, scale=2)
+    backend, frame = _capture_backend(output, frame_w=19, frame_h=10)
+    with pytest.raises(NotImplementedError, match="returned a 19x10 frame"):
+        backend.screenshot(20, 10, numpy.zeros((10, 20, 4), numpy.uint8))
+    assert frame.destroyed
+
+
+# -------- the round trip: request, then crop what comes back --------
+
+
+def _identifiable(w, h):
+    """A frame whose every pixel encodes its own position in the frame."""
+    ys, xs = numpy.mgrid[0:h, 0:w]
+    pixels = numpy.zeros((h, w, 4), numpy.uint8)
+    pixels[:, :, 0] = xs % 251   # B carries the column
+    pixels[:, :, 1] = ys % 241   # G carries the row
+    pixels[:, :, 2] = 0xAA
+    pixels[:, :, 3] = 0xFF
+    return pixels
+
+
+def _pixel_backend(output, frame_w, frame_h, y_invert=False):
+    """A backend faked all the way through the copy, with real pixels.
+
+    Returns the backend, the frame content as the compositor's *upright*
+    view of it, and a list that records the capture request.
+    """
+    backend, _ = _fake_backend([output])
+    upright = _identifiable(frame_w, frame_h)
+    # Y_INVERT says the buffer arrives bottom-up; the backend flips it
+    # back, so hand it the flipped bytes to end up with `upright`.
+    delivered = upright[::-1] if y_invert else upright
+    frame = _FakeFrame(frame_w, frame_h, delivered,
+                       flags=0x1 if y_invert else 0)
+
+    stage = []
+
+    def dispatch(block=True):
+        if not stage:
+            stage.append("buffer")
+            frame.deliver_buffer()
+        else:
+            frame.deliver_ready()
+
+    backend._display = SimpleNamespace(dispatch=dispatch, roundtrip=lambda: None)
+
+    requests = []
+
+    def capture_output(overlay, out):
+        requests.append(("full",))
+        return frame
+
+    def capture_output_region(overlay, out, x, y, w, h):
+        requests.append(("region", x, y, w, h))
+        return frame
+
+    backend._screencopy = SimpleNamespace(
+        capture_output=capture_output,
+        capture_output_region=capture_output_region,
+    )
+    # Stand in for the SHM pool: the backend only ever slices and copies.
+    backend._ensure_buffer = lambda fmt, w, h, stride: (
+        object(), numpy.ascontiguousarray(delivered).tobytes()
+    )
+    return backend, upright, requests
+
+
+def _assert_is_frame_window(img, upright, x0, y0):
+    """``img`` must be exactly the window of ``upright`` at ``(x0, y0)``."""
+    h, w, _ = img.shape
+    numpy.testing.assert_array_equal(img, upright[y0:y0 + h, x0:x0 + w])
+
+
+def test_scale_2_subregion_is_requested_logical_and_cropped_back():
+    """The whole point of the fix, end to end over a fake compositor."""
+    output = _scaled_output(200, 100, 100, 50, scale=2)
+    # logical (10, 5, 10, 5) -> a 20x10 device frame, no surplus
+    backend, upright, requests = _pixel_backend(output, 20, 10)
+
+    img = numpy.zeros((10, 20, 4), numpy.uint8)
+    backend.screenshot(20, 10, img)
+
+    assert requests == [("region", 10, 5, 10, 5)]
+    _assert_is_frame_window(img, upright, 0, 0)
+
+
+def test_scale_2_subregion_crops_off_the_outward_rounding():
+    """An unaligned bbox rounds outward, then the surplus is cropped.
+
+    The device bbox is (21, 11, 20, 10); the logical region rounds out
+    to (10, 5, 11, 6), which comes back as a 22x12 frame whose top-left
+    device pixel is (20, 10). The answer is the 20x10 window one pixel
+    in from that corner.
+    """
+    output = _scaled_output(200, 100, 100, 50, scale=2)
+    backend, upright, requests = _pixel_backend(output, 22, 12)
+
+    img = numpy.zeros((10, 20, 4), numpy.uint8)
+    backend.screenshot(21, 11, img)
+
+    assert requests == [("region", 10, 5, 11, 6)]
+    _assert_is_frame_window(img, upright, 1, 1)
+
+
+def test_fractional_scale_subregion_crops_out_of_the_full_output():
+    """1.5 falls back to a full-output capture and an exact crop."""
+    # 30x15 device over 20x10 logical is a scale of 1.5, which wlroots
+    # would announce as ceil() == 2 on wl_output.scale.
+    output = _scaled_output(30, 15, 20, 10, scale=2)
+    backend, upright, requests = _pixel_backend(output, 30, 15)
+
+    img = numpy.zeros((5, 10, 4), numpy.uint8)
+    backend.screenshot(7, 3, img)
+
+    assert requests == [("full",)]
+    _assert_is_frame_window(img, upright, 7, 3)
+
+
+def test_unknown_logical_size_at_scale_2_crops_out_of_the_full_output():
+    """No xdg_output: the integer scale is an upper bound, so take it all."""
+    output = _output(mode_w=200, mode_h=100, scale=2)  # no logical size
+    backend, upright, requests = _pixel_backend(output, 200, 100)
+
+    img = numpy.zeros((10, 20, 4), numpy.uint8)
+    backend.screenshot(60, 30, img)
+
+    assert requests == [("full",)]
+    _assert_is_frame_window(img, upright, 60, 30)
+
+
+def test_y_invert_is_undone_before_the_crop():
+    """The flag describes the frame, so flip first and crop second."""
+    output = _scaled_output(200, 100, 100, 50, scale=2)
+    backend, upright, _ = _pixel_backend(output, 22, 12, y_invert=True)
+
+    img = numpy.zeros((10, 20, 4), numpy.uint8)
+    backend.screenshot(21, 11, img)
+
+    _assert_is_frame_window(img, upright, 1, 1)
+
+
+def test_full_output_capture_still_copies_the_whole_frame():
+    """The fast path is untouched: no region, no crop."""
+    backend, upright, requests = _pixel_backend(_output(), 100, 50)
+
+    img = numpy.zeros((50, 100, 4), numpy.uint8)
+    backend.screenshot(0, 0, img)
+
+    assert requests == [("full",)]
+    _assert_is_frame_window(img, upright, 0, 0)

--- a/tests/wayland_painter.py
+++ b/tests/wayland_painter.py
@@ -2,15 +2,24 @@
 
 Runs as cage's child app. Cage gives this client the entire output. The
 painter listens on the UNIX socket at ``$XDG_RUNTIME_DIR/fastgrab-painter.sock``
-for newline-terminated commands of the form::
+for newline-terminated commands::
 
     paint #RRGGBB
+    blocks
 
-and redraws its fullscreen surface in that solid color (premultiplied
-ARGB8888 SHM buffer). The surface is set to fullscreen and the painter
-responds to ``xdg_toplevel.configure`` events to keep its buffer the
-same size as the output the compositor gives it — otherwise solid-color
-asserts in the wlr integration tests would see uncovered border pixels.
+``paint`` redraws the fullscreen surface in a solid color (premultiplied
+ARGB8888 SHM buffer). ``blocks`` draws an 8x8 block pattern whose block
+coordinates go into the red and green channels — a solid color cannot
+tell a correctly placed sub-region capture from a displaced one, and
+that placement is the whole subject of issue #38.
+
+The surface is set to fullscreen and the painter responds to
+``xdg_toplevel.configure`` events to keep its buffer the same size as
+the output the compositor gives it — otherwise solid-color asserts in
+the wlr integration tests would see uncovered border pixels. A
+configure also re-applies whichever of the two patterns was last asked
+for, so a mid-test output reconfiguration (the scale change the
+``wlr_output_scale`` fixture makes) does not silently revert the scene.
 
 This file intentionally has no production dependency — it lives under
 ``tests/`` and is only invoked by the test compose service.
@@ -49,6 +58,7 @@ class Painter:
         self.target_w = DEFAULT_W
         self.target_h = DEFAULT_H
         self.color_bgra = (0, 0, 0, 0xFF)
+        self.pattern = "solid"  # "solid" | "blocks"
         self.configured = False
 
         self.display = Display()
@@ -143,10 +153,38 @@ class Painter:
         self.mm.seek(0)
         self.mm.write(pixel * (w * h))
 
+    def _fill_blocks(self, w, h, block=8):
+        """Write an 8x8 block pattern that encodes its own coordinates.
+
+        Red carries the block column, green the block row, so a capture
+        taken from the wrong place holds different values rather than
+        the same flat color. Rows repeat every ``block`` pixels, so the
+        rows are built once each and reused.
+        """
+        rows = {}
+        out = bytearray()
+        for y in range(h):
+            key = (y // block) % 256
+            row = rows.get(key)
+            if row is None:
+                row = bytearray()
+                for x in range(w):
+                    row += struct.pack(
+                        "<BBBB", 0x40, key, (x // block) % 256, 0xFF
+                    )
+                row = bytes(row)
+                rows[key] = row
+            out += row
+        self.mm.seek(0)
+        self.mm.write(bytes(out))
+
     def _redraw(self):
-        b, g, r, a = self.color_bgra
         w, h, _ = self.size
-        self._fill(b, g, r, a, w, h)
+        if self.pattern == "blocks":
+            self._fill_blocks(w, h)
+        else:
+            b, g, r, a = self.color_bgra
+            self._fill(b, g, r, a, w, h)
         self.surface.attach(self.wl_buffer, 0, 0)
         self.surface.damage(0, 0, w, h)
         self.surface.commit()
@@ -159,6 +197,11 @@ class Painter:
         g = int(hex_color[3:5], 16)
         b = int(hex_color[5:7], 16)
         self.color_bgra = (b, g, r, 0xFF)
+        self.pattern = "solid"
+        self._redraw()
+
+    def blocks(self):
+        self.pattern = "blocks"
         self._redraw()
 
 
@@ -217,6 +260,9 @@ def main():
                     try:
                         if line.startswith("paint "):
                             painter.paint(line[6:].strip())
+                            cs.sendall(b"ok\n")
+                        elif line == "blocks":
+                            painter.blocks()
                             cs.sendall(b"ok\n")
                         elif line == "ping":
                             cs.sendall(b"pong\n")


### PR DESCRIPTION
Closes #38.

`WlrBackend.screenshot()` passed a device-pixel bbox straight to
`capture_output_region`, but the protocol specifies that region in **output logical
coordinates** while `resolution()` returns the mode size in physical pixels. Since
#37 the backend refused sub-region requests at `scale != 1` rather than returning
the wrong region; this implements the conversion so the refusal can be lifted.

## What this does

`_plan_region()` maps a device-pixel bbox onto a logical region plus a crop. The
split is about what can be **proved**, not what is likely:

* **Exact integer scale** — floor the origin into logical units, ceil the far edge
  so every requested pixel stays covered, crop the surplus off the returned frame.
  wlroots computes the device box by multiplying by the scale and truncating, which
  is exact for a whole-number scale.

  That `k` is *derived*, not observed: `wl_output.scale` is `ceil()`'d, and
  xdg_output's logical size is `trunc(mode / scale)`, which only bounds the true
  scale from above (`s <= k`). The frame-size check closes the gap — the compositor
  returns `trunc(lw * s)` where the plan predicts `lw * k`, and those agree only
  when `s >= k`. A matching size therefore **proves** `s == k`, and with it the
  origin. An output at 1.999 returns a short frame and is rejected rather than
  silently mis-cropped.
* **Anything else** — fractional scale, or axes that disagree. The device origin
  would be `trunc(lx * s)` for a float `s` not recoverable from protocol integers,
  so any origin but zero risks being a pixel off. Falls back to `capture_output`
  (exactly `mode_w x mode_h`, no scale arithmetic) and crops the bbox out. Correct,
  at the cost of the copy.

Logical geometry comes from `zxdg_output_manager_v1`. pywayland already ships
`pywayland.protocol.xdg_output_unstable_v1`, so **nothing is vendored and no new
runtime dependency is added** — it stays behind the existing `[wayland]` extra, with
the import guarded so a missing binding degrades to the full-output path.

The crop is driven by the buffer event's real width/stride, never the requested size,
and `Y_INVERT` is undone *before* cropping. The b5e834b frame-size check is kept and
now validates the plan's prediction.

## Still refused

Non-normal output transforms (rotation/flip). The existing code only *detected*
transforms and never reasoned about the mapping, so rather than ship a half
implementation the error now names the transform as the specific reason. Full-output
capture is unaffected.

## Tests

The headless `cage` session is scale 1, but cage implements `zwlr_output_manager_v1`,
so `wlr-randr --output HEADLESS-1 --scale N` sets it live. `wlr-randr` is added to
the dev image and a `wlr_output_scale` fixture sets/restores it, giving **real scale-2
and scale-1.5 regression tests**. Since a solid colour proves nothing about placement,
the painter gained a `blocks` pattern encoding its own coordinates, and the assertion
compares a sub-region against the same window of a full-output capture — the one path
the bug cannot touch.

Unit tests cover integer scale 2, the issue's origin displacement, outward rounding
with exact crop offsets, the fractional and disagreeing-axes fallbacks, an exhaustive
covering property over scales 1–4, `Y_INVERT` ordering, and a short frame.

* `docker compose run --rm test` → **211 passed**, 23 deselected
* `docker compose run --rm test-wayland` → **23 passed**, 211 deselected

Checked non-vacuous: raw pass-through fails all 4 scale-2 tests; right-size-but-no-origin
fails 3 of 4.

## Not testable here

Output transforms (cage's headless output is transform-normal), the scale-1.999 case
the proof rejects, and the missing-`zxdg_output_manager_v1` fallback (cage advertises
v3) — all covered by mocked unit tests only.

## Note for whoever merges

This touches the same `base.py` module docstring as #42, in the adjacent bullet.
Whichever lands second needs a one-line conflict resolution: keep both rewritten
bullets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLmJd7aNG8CRS7EQ9waLqD
