### PR TITLE
macos: redraw the capture when the provider is larger than the image

### DIFF
--- a/fastgrab/backends/macos.py
+++ b/fastgrab/backends/macos.py
@@ -20,6 +20,14 @@ and wlr. The bitmap-info bits are double-checked at runtime; an
 unexpected layout raises :class:`RuntimeError` with a clear message
 rather than silently scrambling channels.
 
+Getting the pixels *out* of the returned ``CGImage`` has two paths.
+Normally the image's data provider holds exactly its own rows, and they
+are read straight out of it. When it does not — the provider is allowed
+to be larger than ``bytesPerRow * height``, and on Apple Silicon a
+capture arrives padded out to the 16 KiB page — the image is redrawn
+into a bitmap context whose layout we chose, which is the only way to
+place the pixels without guessing. See :meth:`MacosBackend.screenshot`.
+
 **TCC permission caveat:** macOS 10.15+ requires the running app to
 have *Screen Recording* permission via System Settings → Privacy
 & Security. CI runners (``macos-latest``) typically have this granted
@@ -41,6 +49,14 @@ from .base import BaseBackend
 # CGImageAlphaInfo bits — keep in sync with CoreGraphics/CGImage.h
 _K_CG_BITMAP_BYTE_ORDER_MASK = 0x7000
 _K_CG_BITMAP_BYTE_ORDER_32_LITTLE = 2 << 12  # kCGBitmapByteOrder32Little
+_K_CG_IMAGE_ALPHA_PREMULTIPLIED_FIRST = 2  # kCGImageAlphaPremultipliedFirst
+
+# The layout we ask a bitmap context for: alpha "first" within the 32-bit
+# word, and 32-little reverses that word's bytes, so memory reads B, G,
+# R, A -- fastgrab's cross-platform contract. Screen captures are opaque,
+# so premultiplication is a no-op and only fixes the alpha byte at 255.
+_BGRA_BITMAP_INFO = (_K_CG_IMAGE_ALPHA_PREMULTIPLIED_FIRST
+                     | _K_CG_BITMAP_BYTE_ORDER_32_LITTLE)
 
 
 def _ceil_div(numerator, denominator):
@@ -143,6 +159,29 @@ def _load_frameworks():
     cg.CGDataProviderCopyData.argtypes = [ctypes.c_void_p]
     cg.CGDataProviderCopyData.restype = ctypes.c_void_p
 
+    # The redraw path (see MacosBackend._bitmap_copy).
+    cg.CGImageGetColorSpace.argtypes = [ctypes.c_void_p]
+    cg.CGImageGetColorSpace.restype = ctypes.c_void_p
+    cg.CGColorSpaceCreateDeviceRGB.argtypes = []
+    cg.CGColorSpaceCreateDeviceRGB.restype = ctypes.c_void_p
+    cg.CGColorSpaceRelease.argtypes = [ctypes.c_void_p]
+    cg.CGColorSpaceRelease.restype = None
+    cg.CGBitmapContextCreate.argtypes = [
+        ctypes.c_void_p,   # data
+        ctypes.c_size_t,   # width
+        ctypes.c_size_t,   # height
+        ctypes.c_size_t,   # bitsPerComponent
+        ctypes.c_size_t,   # bytesPerRow
+        ctypes.c_void_p,   # space
+        ctypes.c_uint32,   # bitmapInfo
+    ]
+    cg.CGBitmapContextCreate.restype = ctypes.c_void_p
+    cg.CGContextDrawImage.argtypes = [ctypes.c_void_p, CGRect,
+                                      ctypes.c_void_p]
+    cg.CGContextDrawImage.restype = None
+    cg.CGContextRelease.argtypes = [ctypes.c_void_p]
+    cg.CGContextRelease.restype = None
+
     # ----- CoreFoundation types -----
     cf.CFDataGetBytePtr.argtypes = [ctypes.c_void_p]
     cf.CFDataGetBytePtr.restype = ctypes.c_void_p
@@ -155,6 +194,23 @@ def _load_frameworks():
 
 
 class MacosBackend(BaseBackend):
+    # Class-level so a backend built without __init__ (the tests do this
+    # to bypass framework loading) still has them.
+    #
+    # _draw_via_bitmap latches once a provider is seen that cannot be
+    # read directly, so later frames skip the CGDataProviderCopyData
+    # probe entirely. It only ever turns on: the redraw is correct for
+    # every layout, so a needless one costs speed, never pixels.
+    _draw_via_bitmap = False
+    # Whether to keep offering the image's own colour space to
+    # CGBitmapContextCreate; cleared for good the first time one is
+    # refused, so a display with such a profile does not pay for a
+    # failed create -- and its CoreGraphics stderr complaint -- per
+    # frame.
+    _bitmap_space_from_image = True
+    # Destination for the redraw, reused while the size holds.
+    _scratch = None
+
     def __init__(self):
         cg, cf, CGPoint, CGSize, CGRect = _load_frameworks()
         self._cg = cg
@@ -179,6 +235,10 @@ class MacosBackend(BaseBackend):
         if display == 0:
             raise RuntimeError("CGMainDisplayID returned 0; no main display?")
         self._display = display
+        # A different display can have a different image layout, so let
+        # the next capture re-probe rather than inherit this one's verdict.
+        self._draw_via_bitmap = False
+        self._bitmap_space_from_image = True
 
     def _display_geometry(self):
         """Return ``(pixel_w, pixel_h, point_w, point_h)``.
@@ -332,69 +392,170 @@ class MacosBackend(BaseBackend):
                     "offset {},{}".format(img_w, img_h, w, h, off_x, off_y)
                 )
 
-            provider = self._cg.CGImageGetDataProvider(image)
-            cf_data = self._cg.CGDataProviderCopyData(provider)
-            if not cf_data:
-                raise RuntimeError("CGDataProviderCopyData returned NULL")
+            if row_stride < img_w * 4:
+                # Not a layout any fallback rescues: a 32-bit row cannot
+                # be shorter than four bytes a pixel, so one of these
+                # numbers does not mean what we think it means.
+                raise RuntimeError(
+                    "unsupported row stride: CGImage reports {} bytes "
+                    "per row for a {}-pixel-wide 32-bit image, which "
+                    "needs at least {}. Please open an issue."
+                    .format(row_stride, img_w, img_w * 4)
+                )
 
-            try:
-                src_ptr = self._cf.CFDataGetBytePtr(cf_data)
-                if not src_ptr:
-                    raise RuntimeError("CFDataGetBytePtr returned NULL")
+            # Two ways out of a CGImage, and which one is safe depends
+            # on the provider.
+            #
+            # Reading the provider bytes directly assumes they start at
+            # this image's own top-left with the stride reported above.
+            # A CGImage backed by a *parent* bitmap breaks that: the
+            # stride is the parent's, the data begins at the parent's
+            # origin, and offset 0 is somebody else's pixels.
+            #
+            # Only an exact extent — the provider holding precisely this
+            # image's rows — makes the direct read sound, and it is not
+            # something CoreGraphics promises: CGImageCreate takes the
+            # provider and the extent as separate inputs and requires
+            # only that the buffer hold at least bytesPerRow*height, so
+            # a larger provider is legal. It is also *common*. Issue #46
+            # reports a 1920x1080 capture whose CFData is 8306688 bytes
+            # rather than 8294400 — the pixels rounded up to a whole
+            # 16 KiB page, the arm64 page size. A larger provider cannot
+            # be told apart from a shared parent by size alone, so
+            # anything but an exact match goes the layout-agnostic way
+            # rather than guessing (or, as before, refusing to run).
+            #
+            # A *short* provider stays fatal. That one contradicts
+            # CGImageCreate's own minimum, so our reading of the image
+            # is wrong in some way no fallback repairs, and the direct
+            # read would run off the end of the buffer.
+            copied = False
+            if not self._draw_via_bitmap:
+                provider = self._cg.CGImageGetDataProvider(image)
+                cf_data = self._cg.CGDataProviderCopyData(provider)
+                if not cf_data:
+                    raise RuntimeError("CGDataProviderCopyData returned NULL")
 
-                # The copy trusts that the provider bytes start at this
-                # image's own top-left with the stride reported above. A
-                # CGImage backed by a *parent* bitmap breaks that: the
-                # stride is the parent's and the data begins at the
-                # parent's origin.
-                #
-                # Requiring the provider to hold exactly this image's rows
-                # catches the common shape of that layout, and bounds the
-                # read either way. It cannot *prove* the logical origin —
-                # only a provider of a different extent is detectable —
-                # and it is a deliberate fastgrab invariant rather than a
-                # documented CoreGraphics one: CGImageCreate takes the
-                # provider and the extent as separate inputs and only
-                # requires the buffer to be at least bytesPerRow*height,
-                # so an over-allocated provider is not forbidden. Failing
-                # closed is the right trade here — the alternative is
-                # returning someone else's pixels.
-                if row_stride < img_w * 4:
-                    raise RuntimeError(
-                        "unsupported row stride: CGImage reports {} bytes "
-                        "per row for a {}-pixel-wide 32-bit image, which "
-                        "needs at least {}. Please open an issue."
-                        .format(row_stride, img_w, img_w * 4)
-                    )
+                try:
+                    src_ptr = self._cf.CFDataGetBytePtr(cf_data)
+                    if not src_ptr:
+                        raise RuntimeError("CFDataGetBytePtr returned NULL")
 
-                data_len = self._cf.CFDataGetLength(cf_data)
-                expected = row_stride * img_h
-                if data_len != expected:
-                    raise RuntimeError(
-                        "unsupported provider extent: CFData holds {} bytes "
-                        "for a {}x{} image with a {}-byte row stride, where "
-                        "{} was expected. fastgrab reads the provider bytes "
-                        "directly and cannot locate the image inside a "
-                        "buffer of another size. Please open an issue."
-                        .format(data_len, img_w, img_h, row_stride, expected)
-                    )
+                    data_len = self._cf.CFDataGetLength(cf_data)
+                    minimum = row_stride * img_h
+                    if data_len < minimum:
+                        raise RuntimeError(
+                            "truncated provider: CFData holds {} bytes for a "
+                            "{}x{} image with a {}-byte row stride, which "
+                            "needs at least {}. Reading it would run past "
+                            "the end of the buffer. Please open an issue."
+                            .format(data_len, img_w, img_h, row_stride,
+                                    minimum)
+                        )
 
-                # One strided view over the provider bytes, sliced to the
-                # requested region and copied in a single C-level pass.
-                # Row padding (Apple often aligns to 16 bytes) and a
-                # snapped left edge are both just slicing here; done with
-                # per-row memmoves they cost an interpreter round trip
-                # per row, and a snapped left edge is the common case for
-                # sub-rect captures on a 2x display.
-                src = numpy.frombuffer(
-                    (ctypes.c_ubyte * (row_stride * img_h)).from_address(
-                        src_ptr),
-                    dtype=numpy.uint8,
-                ).reshape(img_h, row_stride)
+                    if data_len == minimum:
+                        # One strided view over the provider bytes,
+                        # sliced to the requested region and copied in a
+                        # single C-level pass. Row padding (Apple often
+                        # aligns to 16 bytes) and a snapped left edge are
+                        # both just slicing here; done with per-row
+                        # memmoves they cost an interpreter round trip
+                        # per row, and a snapped left edge is the common
+                        # case for sub-rect captures on a 2x display.
+                        src = numpy.frombuffer(
+                            (ctypes.c_ubyte * minimum).from_address(src_ptr),
+                            dtype=numpy.uint8,
+                        ).reshape(img_h, row_stride)
+                        img[:] = src[
+                            off_y:off_y + h, off_x * 4:(off_x + w) * 4
+                        ].reshape(h, w, 4)
+                        copied = True
+                    else:
+                        # Latch, so the next frame goes straight to the
+                        # redraw instead of paying for this copy to
+                        # re-learn the same answer.
+                        self._draw_via_bitmap = True
+                finally:
+                    self._cf.CFRelease(cf_data)
+
+            if not copied:
+                src = self._bitmap_copy(image, img_w, img_h)
                 img[:] = src[
                     off_y:off_y + h, off_x * 4:(off_x + w) * 4
                 ].reshape(h, w, 4)
-            finally:
-                self._cf.CFRelease(cf_data)
         finally:
             self._cg.CGImageRelease(image)
+
+    def _bitmap_copy(self, image, img_w, img_h):
+        """Redraw ``image`` into a bitmap whose layout we chose.
+
+        ``CGContextDrawImage`` is the layout-agnostic way to get pixels
+        out of a ``CGImage``: CoreGraphics resolves the provider, the
+        stride and any parent-bitmap origin itself, so none of them can
+        be guessed wrong here, and the destination is BGRA8 because we
+        asked for BGRA8.
+
+        Returns an ``(img_h, img_w * 4)`` uint8 array — the same shape
+        the direct read produces, so the caller slices it identically.
+        The buffer is reused across captures of the same size.
+        """
+        stride = img_w * 4
+        scratch = self._scratch
+        if scratch is None or scratch.shape != (img_h, stride):
+            # zeros rather than empty: were a draw ever to fail without
+            # saying so, the caller gets black, not heap contents.
+            scratch = numpy.zeros((img_h, stride), numpy.uint8)
+            self._scratch = scratch
+
+        # Offer the image's own colour space first. Source and
+        # destination spaces matching is what keeps this a pure layout
+        # conversion — CoreGraphics colour-matches between differing
+        # spaces, which would quietly hand back different pixel values
+        # than the direct read does on a wide-gamut display. Device RGB
+        # is the fallback for a space a bitmap context will not accept
+        # (an extended-range/EDR profile needs float components), and it
+        # does convert.
+        space = None
+        own_space = False
+        if self._bitmap_space_from_image:
+            # Get rule: that reference is the image's, not ours to release.
+            space = self._cg.CGImageGetColorSpace(image)
+        context = None
+        if space:
+            context = self._cg.CGBitmapContextCreate(
+                scratch.ctypes.data, img_w, img_h, 8, stride, space,
+                _BGRA_BITMAP_INFO)
+            if not context:
+                self._bitmap_space_from_image = False
+        if not context:
+            # Create rule: we own this one and must release it.
+            space = self._cg.CGColorSpaceCreateDeviceRGB()
+            own_space = True
+            if space:
+                context = self._cg.CGBitmapContextCreate(
+                    scratch.ctypes.data, img_w, img_h, 8, stride, space,
+                    _BGRA_BITMAP_INFO)
+
+        try:
+            if not context:
+                raise RuntimeError(
+                    "CGBitmapContextCreate returned NULL for a {}x{} BGRA8 "
+                    "bitmap; fastgrab cannot convert this CGImage. Please "
+                    "open an issue.".format(img_w, img_h)
+                )
+            # Exactly the image's own size, so the transform is the
+            # identity and nothing is resampled. A bitmap context's
+            # first row in memory is its top row, so this lands upright
+            # despite the y-up coordinate space.
+            rect = self._CGRect(
+                origin=self._CGPoint(x=0.0, y=0.0),
+                size=self._CGSize(width=float(img_w), height=float(img_h)),
+            )
+            self._cg.CGContextDrawImage(context, rect, image)
+        finally:
+            if context:
+                self._cg.CGContextRelease(context)
+            if own_space and space:
+                self._cg.CGColorSpaceRelease(space)
+
+        return scratch

--- a/tests/test_macos_backend.py
+++ b/tests/test_macos_backend.py
@@ -11,6 +11,15 @@ under-report its pixel size so an oversized capture can be exercised,
 and CoreGraphics and CoreFoundation are separate objects so a symbol
 called on the wrong framework handle fails here the way it would on a
 real machine.
+
+The provider is modelled as real bytes for the same reason. It can be
+over-allocated (``provider_pad`` — issue #46: a 1920x1080 capture whose
+CFData is padded out to the 16 KiB arm64 page), and it can be a
+*parent* bitmap the image is merely a window onto (``parent_margin``),
+where the pixels start at a non-zero offset and the byte pointer aims
+at somebody else's top-left corner. Everything outside the image is
+filled with 0xA5, so a capture read at the wrong offset or stride comes
+back with wrong *values*, not merely a different call count.
 """
 import ctypes
 from types import SimpleNamespace
@@ -55,15 +64,48 @@ def test_rect_is_unchanged_without_scaling(rect):
     assert _snap_rect_to_points(*rect, **FLAT) == (x, y, w, h, 0, 0)
 
 
+# Colour-space handles. Plain strings, so a mix-up shows up by name.
+_DEVICE_RGB = "device-rgb"
+_IMAGE_RGB = "image-rgb"
+
+# kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little. Spelled
+# out rather than imported from the backend: this is the ABI constant
+# that makes the destination BGRA, and the point of asserting on it is
+# to catch the backend changing it.
+_BGRA8888 = 2 | (2 << 12)
+
+
+class _FakeImage:
+    """The layout CoreGraphics knows about; the backend can only ask.
+
+    ``data_offset`` is where this image's first pixel sits inside the
+    provider. It is non-zero exactly when the image is a window onto a
+    larger parent bitmap — the case the byte pointer cannot reveal.
+    """
+
+    def __init__(self, w, h, stride, data_offset, buf):
+        self.w = w
+        self.h = h
+        self.stride = stride
+        self.data_offset = data_offset
+        self.buf = buf
+
+
 class _FakeCoreGraphics:
     """The slice of CoreGraphics the backend calls, over a numpy screen."""
 
     def __init__(self, screen, point_w, point_h, row_pad=0,
-                 mode_pixel_w=None, mode_pixel_h=None):
+                 mode_pixel_w=None, mode_pixel_h=None, provider_pad=0,
+                 parent_margin=0):
         self.screen = screen
         self.pixel_h, self.pixel_w = screen.shape[:2]
         self.point_w, self.point_h = point_w, point_h
         self.row_pad = row_pad
+        # Bytes the provider holds beyond the image's own rows. Legal per
+        # CGImageCreate, and what issue #46 hits.
+        self.provider_pad = provider_pad
+        # Pixels of surrounding parent bitmap the provider also covers.
+        self.parent_margin = parent_margin
         # What CGDisplayModeGetPixel{Width,Height} claim. Defaults to the
         # real backing store; a test can make the mode under-report to
         # model a display whose mode dict omits the HiDPI pixel fields.
@@ -71,6 +113,17 @@ class _FakeCoreGraphics:
         self.mode_pixel_h = self.pixel_h if mode_pixel_h is None else mode_pixel_h
         self.bits_per_component = 8
         self.main_display = 1
+        # The colour space CGImageGetColorSpace hands back, and the ones
+        # CGBitmapContextCreate refuses (an EDR profile needs float
+        # components, so a real one refuses and logs).
+        self.image_colorspace = _IMAGE_RGB
+        self.refuse_colorspaces = set()
+        self.colorspace_queries = 0
+        self.created_colorspaces = []
+        self.released_colorspaces = []
+        self.copy_data_calls = 0
+        self.contexts = {}
+        self.open_contexts = set()
         self._meta = {}
         self._buffers = {}
 
@@ -104,13 +157,27 @@ class _FakeCoreGraphics:
                 "rect %r falls outside the %dx%d screen; real CoreGraphics "
                 "clips to the display bounds and returns a smaller image"
                 % ((x, y, w, h), self.pixel_w, self.pixel_h))
-        stride = w * 4 + self.row_pad
-        buf = (ctypes.c_ubyte * (stride * h))()
-        for index, row in enumerate(self.screen[y:y + h, x:x + w]):
+        # The provider covers the parent rect, which is this image grown
+        # by parent_margin and clipped to the screen. At margin 0 the two
+        # coincide and the image owns its buffer outright.
+        margin = self.parent_margin
+        par_x = max(0, x - margin)
+        par_y = max(0, y - margin)
+        par_w = min(self.pixel_w, x + w + margin) - par_x
+        par_h = min(self.pixel_h, y + h + margin) - par_y
+        stride = par_w * 4 + self.row_pad
+        buf = (ctypes.c_ubyte * (stride * par_h + self.provider_pad))()
+        # Fill first, so row padding and any over-allocation hold
+        # something recognisable rather than zeros: pixels fetched from
+        # the wrong place then differ in value, not just in provenance.
+        ctypes.memset(buf, 0xA5, len(buf))
+        for index, row in enumerate(
+                self.screen[par_y:par_y + par_h, par_x:par_x + par_w]):
             ctypes.memmove(ctypes.byref(buf, index * stride), row.tobytes(),
-                           w * 4)
+                           par_w * 4)
         token = len(self._meta) + 1
-        self._meta[token] = (w, h, stride)
+        self._meta[token] = _FakeImage(
+            w, h, stride, (y - par_y) * stride + (x - par_x) * 4, buf)
         self._buffers[token] = buf
         return token
 
@@ -132,13 +199,13 @@ class _FakeCoreGraphics:
                            int(asked[2] * scale_x), int(asked[3] * scale_y))
 
     def CGImageGetWidth(self, image):
-        return self._meta[image][0]
+        return self._meta[image].w
 
     def CGImageGetHeight(self, image):
-        return self._meta[image][1]
+        return self._meta[image].h
 
     def CGImageGetBytesPerRow(self, image):
-        return self._meta[image][2]
+        return self._meta[image].stride
 
     def CGImageGetBitsPerPixel(self, image):
         return 32
@@ -153,10 +220,61 @@ class _FakeCoreGraphics:
         return image
 
     def CGDataProviderCopyData(self, provider):
+        self.copy_data_calls += 1
         return provider
 
     def CGImageRelease(self, image):
         pass
+
+    # ----- the redraw path -----
+
+    def CGImageGetColorSpace(self, image):
+        self.colorspace_queries += 1
+        return self.image_colorspace
+
+    def CGColorSpaceCreateDeviceRGB(self):
+        self.created_colorspaces.append(_DEVICE_RGB)
+        return _DEVICE_RGB
+
+    def CGColorSpaceRelease(self, space):
+        self.released_colorspaces.append(space)
+
+    def CGBitmapContextCreate(self, data, width, height, bits_per_component,
+                              stride, space, info):
+        # Pin the destination layout: anything else here and the array
+        # handed back would not be the 8-bit BGRA the project promises.
+        assert bits_per_component == 8, bits_per_component
+        assert info == _BGRA8888, hex(info)
+        assert stride == width * 4, (stride, width)
+        assert data, "bitmap context created over a NULL buffer"
+        if space in self.refuse_colorspaces:
+            # What a real CGBitmapContextCreate does with a colour space
+            # the pixel format cannot carry: NULL, plus stderr noise.
+            return 0
+        token = "ctx%d" % (len(self.contexts) + 1)
+        self.contexts[token] = (data, width, height, stride)
+        self.open_contexts.add(token)
+        return token
+
+    def CGContextDrawImage(self, context, rect, image):
+        dest, width, height, dest_stride = self.contexts[context]
+        meta = self._meta[image]
+        # The backend must ask for the image at its own size at the
+        # origin; any other rect means it is doing arithmetic that
+        # CoreGraphics is supposed to be doing for it.
+        assert (rect.origin.x, rect.origin.y) == (0.0, 0.0), rect.origin
+        assert (rect.size.width, rect.size.height) == (meta.w, meta.h)
+        assert (width, height) == (meta.w, meta.h), (width, height)
+        # CoreGraphics reads through its own knowledge of the layout —
+        # the parent's stride and this image's offset within it.
+        for row in range(height):
+            start = meta.data_offset + row * meta.stride
+            ctypes.memmove(dest + row * dest_stride,
+                           bytes(meta.buf[start:start + width * 4]),
+                           width * 4)
+
+    def CGContextRelease(self, context):
+        self.open_contexts.discard(context)
 
 
 class _FakeCoreFoundation:
@@ -182,12 +300,14 @@ class _FakeCoreFoundation:
 
 
 def _backend(point_w=20, point_h=15, row_pad=0,
-             mode_pixel_w=None, mode_pixel_h=None):
+             mode_pixel_w=None, mode_pixel_h=None, provider_pad=0,
+             parent_margin=0):
     """A MacosBackend wired to fakes, bypassing framework loading."""
     screen = numpy.random.default_rng(0).integers(
         0, 256, (30, 40, 4), dtype=numpy.uint8)
     cg = _FakeCoreGraphics(screen, point_w, point_h, row_pad,
-                           mode_pixel_w, mode_pixel_h)
+                           mode_pixel_w, mode_pixel_h, provider_pad,
+                           parent_margin)
     cf = _FakeCoreFoundation(cg)
     backend = object.__new__(MacosBackend)
     backend._cg = cg
@@ -262,19 +382,19 @@ def test_oversized_full_screen_image_is_rejected():
         _capture(backend, 0, 0, 20, 16)
 
 
-def test_oversized_cfdata_is_rejected():
-    """The parent-bitmap layout makes the provider *larger*, not shorter.
+def test_a_longer_provider_than_expected_is_redrawn_not_refused():
+    """Issue #46: refusing an over-allocated provider broke real Macs.
 
-    A short-buffer check alone never fires for it: a cropped CGImage
-    sharing its parent's storage reports the parent's stride and hands
-    back the parent's bytes, so every row is read from the wrong origin
-    while all the size checks pass.
+    The extent is the only handle on whether the bytes belong to this
+    image alone, so an unexplained one must not be *read* — but it must
+    not be fatal either, since CGImageCreate allows it outright.
     """
-    backend, _, cf = _backend()
+    backend, cg, cf = _backend()
     real = cf.CFDataGetLength
     cf.CFDataGetLength = lambda data: real(data) + 4096
-    with pytest.raises(RuntimeError, match="unsupported provider extent"):
-        _capture(backend, 7, 5, 11, 9)
+    assert numpy.array_equal(_capture(backend, 7, 5, 11, 9),
+                             cg.screen[5:14, 7:18])
+    assert cg.contexts, "should have fallen back to a bitmap context"
 
 
 def test_stride_narrower_than_a_row_is_rejected():
@@ -383,3 +503,188 @@ def test_out_of_bounds_rect_is_not_silently_zero_padded():
     backend, cg, _ = _backend()
     with pytest.raises(AssertionError, match="outside the"):
         cg._image(35, 28, 10, 10)
+
+
+# --------------------------------------------------------------------
+# Issue #46: the data provider is allowed to be bigger than the image.
+#
+# On the reported machine — 1920x1080, a 7680-byte stride — the CFData
+# is 8306688 bytes where the pixels need 8294400. The difference is
+# 12288, which is exactly what rounding 8294400 up to a whole 16 KiB
+# arm64 page costs. Reading such a provider from offset 0 happens to be
+# right; reading a *parent-bitmap* one, which is over-allocated in the
+# same undetectable way, is not. So over-allocation gets redrawn.
+# --------------------------------------------------------------------
+
+# 8294400 -> 8306688, scaled down to this 40x30 screen: any pad that is
+# neither zero nor a whole number of rows.
+PAGE_PAD = 12288
+
+
+def test_the_reported_extent_is_a_16k_page_rounding():
+    """Documents the diagnosis the fallback is built around."""
+    pixels = 1920 * 1080 * 4
+    page = 16 * 1024                      # arm64 macOS page size
+    assert pixels == 8294400
+    assert -(-pixels // page) * page == 8306688
+
+
+@pytest.mark.parametrize("row_pad", [0, 12])
+@pytest.mark.parametrize("x, y, w, h", [
+    (0, 0, 40, 30),      # full screen — the shape issue #46 reports
+    (0, 0, 8, 6),
+    (7, 5, 11, 9),       # odd offset and size -> sub-rectangle copy
+    (39, 29, 1, 1),
+])
+def test_over_allocated_provider_captures_the_right_pixels(x, y, w, h,
+                                                           row_pad):
+    """The reported failure, now a capture — with the pixels checked.
+
+    ``row_pad`` covers a stride wider than width*4 on the same path, so
+    the redraw's tight destination stride is exercised against a padded
+    source.
+    """
+    backend, cg, _ = _backend(row_pad=row_pad, provider_pad=PAGE_PAD)
+    img = _capture(backend, x, y, w, h)
+    assert numpy.array_equal(img, cg.screen[y:y + h, x:x + w])
+    assert cg.contexts, "an unexplained extent must not be read directly"
+
+
+@pytest.mark.parametrize("x, y, w, h", [
+    (0, 0, 40, 30),
+    (7, 5, 11, 9),
+])
+def test_an_exact_provider_still_takes_the_direct_read(x, y, w, h):
+    """The fast path is the point; only anomalies pay for a redraw."""
+    backend, cg, _ = _backend()
+    assert numpy.array_equal(_capture(backend, x, y, w, h),
+                             cg.screen[y:y + h, x:x + w])
+    assert cg.contexts == {}, "no redraw should have been needed"
+    assert cg.copy_data_calls == 1
+
+
+def test_sub_image_of_a_parent_bitmap_is_not_read_from_offset_zero():
+    """The hazard the extent check was standing in for, met head on.
+
+    The image is a window onto a larger bitmap: the stride is the
+    parent's and the byte pointer aims at the *parent's* top-left. The
+    redraw asks CoreGraphics where the pixels really are; reading from
+    offset 0 would return a neighbouring region instead.
+    """
+    backend, cg, cf = _backend(parent_margin=2)
+    img = _capture(backend, 7, 5, 11, 9)
+    assert numpy.array_equal(img, cg.screen[5:14, 7:18])
+
+    # And the fake really does pose the hazard: offset 0 with the
+    # reported stride is a different picture, so the test above cannot
+    # pass by accident.
+    token = max(cg._meta)
+    meta = cg._meta[token]
+    assert meta.data_offset > 0
+    naive = numpy.frombuffer(
+        bytes(meta.buf[:meta.stride * meta.h]), dtype=numpy.uint8
+    ).reshape(meta.h, meta.stride)[1:10, 4:48].reshape(9, 11, 4)
+    assert not numpy.array_equal(naive, cg.screen[5:14, 7:18])
+
+
+def test_the_redraw_verdict_is_reached_once_not_per_frame():
+    """CGDataProviderCopyData copies the whole frame; do not re-pay it."""
+    backend, cg, _ = _backend(provider_pad=PAGE_PAD)
+    for _ in range(3):
+        assert numpy.array_equal(_capture(backend, 0, 0, 40, 30), cg.screen)
+    assert cg.copy_data_calls == 1, "only the probing frame should copy"
+    assert len(cg.contexts) == 3
+
+
+def test_refresh_re_probes_the_provider():
+    """A different main display can have a different image layout."""
+    backend, cg, _ = _backend(provider_pad=PAGE_PAD)
+    _capture(backend, 0, 0, 40, 30)
+    assert backend._draw_via_bitmap is True
+    backend.refresh()
+    assert backend._draw_via_bitmap is False
+    _capture(backend, 0, 0, 40, 30)
+    assert cg.copy_data_calls == 2
+
+
+def test_a_short_provider_is_refused_rather_than_redrawn():
+    """Under-length is a different animal from over-length.
+
+    Over-allocation is legal and merely unreadable; a provider shorter
+    than bytesPerRow*height contradicts CGImageCreate itself, so the
+    image is not what we think it is and no fallback can repair that.
+    Reading it would run off the end of the buffer.
+    """
+    backend, cg, cf = _backend()
+    real = cf.CFDataGetLength
+    cf.CFDataGetLength = lambda data: real(data) - 1
+    with pytest.raises(RuntimeError, match="truncated provider"):
+        _capture(backend, 7, 5, 11, 9)
+    assert cg.contexts == {}, "a broken image must not be quietly redrawn"
+    assert backend._draw_via_bitmap is False
+
+
+def test_redraw_uses_the_images_own_colour_space():
+    """Matching spaces keep the redraw a pure layout conversion.
+
+    Drawing into a device-RGB context colour-matches out of a
+    wide-gamut profile, which would hand back different values than the
+    direct read does for the same screen.
+    """
+    backend, cg, _ = _backend(provider_pad=PAGE_PAD)
+    _capture(backend, 0, 0, 40, 30)
+    assert cg.created_colorspaces == []
+    # Get rule: the image's colour space is not ours to release.
+    assert cg.released_colorspaces == []
+
+
+@pytest.mark.parametrize("image_colorspace, refused", [
+    (_IMAGE_RGB, {_IMAGE_RGB}),   # e.g. an EDR profile a bitmap won't take
+    (0, set()),                   # CGImageGetColorSpace returned NULL
+])
+def test_redraw_falls_back_to_device_rgb(image_colorspace, refused):
+    backend, cg, _ = _backend(provider_pad=PAGE_PAD)
+    cg.image_colorspace = image_colorspace
+    cg.refuse_colorspaces = refused
+    assert numpy.array_equal(_capture(backend, 0, 0, 40, 30), cg.screen)
+    assert cg.created_colorspaces == [_DEVICE_RGB]
+    # Create rule: this one *is* ours, and must not leak.
+    assert cg.released_colorspaces == [_DEVICE_RGB]
+
+
+def test_a_refused_colour_space_is_not_retried_every_frame():
+    """A real refusal also writes to stderr; once is plenty."""
+    backend, cg, _ = _backend(provider_pad=PAGE_PAD)
+    cg.refuse_colorspaces = {_IMAGE_RGB}
+    for _ in range(3):
+        _capture(backend, 0, 0, 40, 30)
+    assert cg.colorspace_queries == 1
+    assert cg.created_colorspaces == [_DEVICE_RGB] * 3
+
+
+def test_a_bitmap_context_that_cannot_be_made_is_reported():
+    backend, cg, _ = _backend(provider_pad=PAGE_PAD)
+    cg.refuse_colorspaces = {_IMAGE_RGB, _DEVICE_RGB}
+    with pytest.raises(RuntimeError, match="CGBitmapContextCreate"):
+        _capture(backend, 0, 0, 40, 30)
+    # even on the failing path the created colour space is released
+    assert cg.released_colorspaces == [_DEVICE_RGB]
+
+
+def test_the_redraw_releases_its_context():
+    backend, cg, _ = _backend(provider_pad=PAGE_PAD)
+    for _ in range(3):
+        _capture(backend, 0, 0, 40, 30)
+    assert cg.open_contexts == set()
+
+
+def test_the_redraw_buffer_is_reused_across_frames():
+    """A per-frame 8 MB allocation on the affected path is avoidable."""
+    backend, cg, _ = _backend(provider_pad=PAGE_PAD)
+    _capture(backend, 0, 0, 40, 30)
+    first = backend._scratch
+    _capture(backend, 0, 0, 40, 30)
+    assert backend._scratch is first
+    # a different size has to reallocate, and must not reuse stale rows
+    assert numpy.array_equal(_capture(backend, 7, 5, 11, 9),
+                             cg.screen[5:14, 7:18])


### PR DESCRIPTION
Fixes #46. A user on Apple Silicon cannot capture at all — the two-line API raises.

## What the numbers say

The report gives a 1920x1080 capture, a 7680-byte row stride and a CFData of
8,306,688 bytes where 8,294,400 was expected. The stride is not the problem
(7680 = 1920x4); the provider is simply **larger** than the image needs.

The extra 12,288 bytes are exactly page rounding — to a **16 KiB** page, which is
the arm64 page size, not the 4 KiB one:

```
8294400 mod 16384 = 4096      ->  16384 - 4096 = 12288
ceil(8294400 / 16384) * 16384 = 507 * 16384 = 8306688   <- the reported length
```

8,294,400 *is* a multiple of 4096, which is why a 4 KiB model makes page rounding
look like the wrong explanation. It is an exact fit against a physically
meaningful constant. Diagnosed, not measured — see the caveats at the end.

## Why not just relax the check

The old comment justified failing closed by the risk that a `CGImage` can be a
window onto a larger shared parent buffer, where reading from offset 0 returns
someone else's pixels.

That risk is real, but the extent check was a **weaker guard than it claimed**: a
sub-image cropped *horizontally only* from a same-height parent satisfies
`data_len == row_stride * img_h` exactly, so the check never fires for it. And the
size alone cannot separate page rounding from a shared parent — here the slack
(12,288) is larger than a whole row (7,680), so even "slack smaller than one row"
would reject the reported case.

So plain `data_len >= minimum` would trade one user's loud error for a silent
wrong-pixels bug. Mutation-checked: making exactly that change fails **16 tests**,
including one that fails on an array-value comparison rather than a call count.

Always redrawing was rejected too — it would change behaviour for **every**
existing macOS user, adding an unmeasured per-frame cost and risking silent colour
drift on wide-gamut displays, to fix a case most of them do not have. PR #37's
direct path was validated on real hardware; it should stay the default.

## The fix

Three-way on the provider length:

| provider | behaviour |
|---|---|
| **shorter** than `row_stride * height` | still fatal — contradicts `CGImageCreate`'s own minimum, and reading it would run off the end |
| **exactly** that size | direct read, byte-for-byte the existing path |
| **larger** | redraw via `CGBitmapContextCreate` + `CGContextDrawImage` |

The redraw makes provider layout, stride, sub-image origin and colour space all
CoreGraphics' problem. Three things stop it costing more than it fixes:

* the verdict **latches**, so only the first frame pays for the probing copy;
  `refresh()` clears it;
* the destination buffer is reused across same-sized frames;
* the context uses **the image's own colour space**, so the draw is a pure layout
  conversion with no colour matching. Device RGB is only a fallback for when a
  bitmap context refuses that space (EDR profiles need float components), and that
  refusal latches too rather than being retried and CG-logged every frame.

Destination format is `kCGImageAlphaPremultipliedFirst | kCGBitmapByteOrder32Little`
= BGRA, matching the project contract, pinned in the tests by the literal ABI
constant rather than by importing the backend's own name. PR #37's Retina
behaviour is untouched: the `off_x`/`off_y` slice is byte-identical on both paths,
and 1x displays that work today still take the direct read.

## Tests

`tests/test_macos_backend.py` goes 45 -> 67. The fakes now model the provider as
**real bytes** with filler outside the image, plus `provider_pad` (over-allocation)
and `parent_margin` (a sub-image over a shared parent, with a non-zero data offset).
The fake `CGContextDrawImage` blits through the parent stride and offset, modelling
CG knowing the true layout.

Covered: exact provider still takes the direct read (asserts no context is
created); over-allocated provider captures correct pixels across four rects x
`row_pad` in {0, 12}; short provider still raises and is not rerouted; parent-bitmap
sub-image returns the right region, with an in-test assertion that an offset-0 read
returns a demonstrably *different* picture so the test cannot pass vacuously;
probe-once latching; `refresh()` re-probing; colour-space Get/Create release rules;
both-refused error; no context leak; buffer reuse.

`docker compose run --rm test` -> **273 passed**.

## What is NOT verified

**No line of this has run on a Mac.** All 67 macOS tests are mocked ctypes on Linux.
Unproven: that the reporter's configuration now captures; that `CGContextDrawImage`
yields the image upright and unresampled at the identity transform; that
`CGBitmapContextCreate` accepts a real display colour space at 8bpc/BGRA, and that
the device-RGB fallback ever executes; that redrawn bytes equal direct-read bytes
where both paths are possible; and the fallback's real per-frame cost.

The `macos` CI job proves the **fast path is unbroken** and that the six new symbols
resolve, since a `macos-latest` runner is 1x with an exactly-sized provider — it
never enters the redraw. It does not exercise the fallback at all. Confirming that
needs an Apple Silicon Mac, ideally the reporter's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLmJd7aNG8CRS7EQ9waLqD
