### PR TITLE
x11: cache the display connection instead of one per call

### DIFF
--- a/fastgrab/backends/x11.py
+++ b/fastgrab/backends/x11.py
@@ -1,4 +1,16 @@
-"""X11 backend — thin shim over the ``fastgrab._linux_x11`` C extension."""
+"""X11 backend — thin shim over the ``fastgrab._linux_x11`` C extension.
+
+The extension keeps **one X connection per process**, keyed on
+``DISPLAY``. It used to open and close a connection around every single
+request — two per ``capture()``, since ``bytes_per_pixel`` opens one of
+its own — which is the churn issue #44 blames for the intermittent
+"cannot open X display". Nothing on this side has to manage that: a
+caller who repoints ``DISPLAY`` is served by a new connection on the
+next call, a forked child connects for itself, and a server that goes
+away is reported as an exception rather than exiting the interpreter.
+The extension's ``_display_cache_info()`` and ``_close_display()`` are
+private and exist for ``tests/test_x11_lowlevel.py``.
+"""
 import functools
 import os
 

--- a/fastgrab/linux_x11/screenshot.c
+++ b/fastgrab/linux_x11/screenshot.c
@@ -112,7 +112,13 @@ static const char *fg_strerror(int code)
  *    fg_io_error_handler() below longjmps back out instead, the dead
  *    connection is dropped, and the call is retried once on a fresh one
  *    so that a restarted server keeps behaving the way it did when every
- *    call opened its own connection.
+ *    call opened its own connection. Two things this depends on are easy
+ *    to get subtly wrong, and both were: the handler has to be armed
+ *    around *every* Xlib call on a connection that might be dead --
+ *    XCloseDisplay included, since dropping a stale connection on a
+ *    DISPLAY switch is itself I/O -- and it has to be (re)installed per
+ *    armed region, because Xlib's handler is process-global and any
+ *    other Xlib user can replace it between two of our calls.
  *
  * Nothing tears the connection down at interpreter shutdown, on purpose.
  * The repo already avoids finalizer-ordering hazards (the wlr and
@@ -152,40 +158,47 @@ static int fg_display_name_matches(const char *env)
     return strcmp(env, fg_display_name) == 0;
 }
 
-/* Forget the cached connection.
+/* Reclaim just the descriptor of a connection we are giving up on.
  *
- * close_connection tells XCloseDisplay whether it may talk to the
- * server. It may not when the socket is shared with a parent process
- * (post-fork) or is already dead (I/O error): in both cases the protocol
- * write would either corrupt someone else's stream or re-enter the I/O
- * error path. The Display struct is then leaked -- once per fork and
- * once per server death, never per call -- and only the descriptor is
- * reclaimed. Closing our own descriptor sends nothing to the server and
- * leaves the parent's copy of the socket untouched. */
-static void fg_drop_display(int close_connection)
+ * Sends nothing to the server, so it is safe on a socket shared with a
+ * parent process (post-fork) and on one that is already dead. The
+ * Display struct is leaked in exchange -- once per fork and once per
+ * server death, never per call. */
+static void fg_close_connection_fd(Display *dpy)
 {
-    if (fg_display != NULL) {
-        if (close_connection) {
-            XCloseDisplay(fg_display);
-        } else {
-            int fd = ConnectionNumber(fg_display);
-            if (fd >= 0)
-                close(fd);
-        }
-    }
-    fg_display = NULL;
-    free(fg_display_name);
-    fg_display_name = NULL;
-    fg_display_pid = 0;
+    int fd = ConnectionNumber(dpy);
+
+    if (fd >= 0)
+        close(fd);
 }
 
 /* ------------------------------------------------------------------ *
  * I/O error recovery
  *
- * Installed lazily, on the first successful connect, so merely importing
- * fastgrab does not change process-global Xlib state. Re-installed on
- * every connect so that a host application which set its own handler in
- * the meantime is chained to rather than clobbered.
+ * Xlib's default I/O error handler prints and calls exit(), so any Xlib
+ * call on a connection whose server has gone away takes the interpreter
+ * with it -- no exception, no traceback. Every such call therefore runs
+ * inside an armed region: the handler below longjmps back out, and the
+ * caller drops the connection and reports an error.
+ *
+ * "Every such call" includes XCloseDisplay. It sends a KillClient and
+ * XSyncs before disconnecting, which is real I/O on a socket that may
+ * already be dead. Switching DISPLAY away from a server that had died
+ * while idle used to close that stale connection outside any armed
+ * region, so the fault reached Xlib's fatal handler and exited the
+ * interpreter -- even though the newly named display was perfectly
+ * healthy and the call was about to succeed.
+ *
+ * The handler is installed at the top of every armed region rather than
+ * once per connection. Xlib keeps a single process-global handler, so
+ * any other Xlib user in the process -- Tk under recording/gui, for one
+ * -- can replace or clear it at any time; installing only on connect
+ * left every later cache hit running under someone else's fatal handler
+ * with the setjmp below inert. Re-installing is a pointer swap, and the
+ * prev != ours test keeps the chain honest: it never records this
+ * handler as its own predecessor (which would recurse instead of
+ * longjmping), and it picks up a third-party handler installed since
+ * the previous region.
  * ------------------------------------------------------------------ */
 
 static jmp_buf fg_io_jmp;
@@ -199,7 +212,7 @@ static int fg_io_error_handler(Display *dpy)
         fg_io_armed = 0;
         longjmp(fg_io_jmp, 1);  /* does not return */
     }
-    /* Not our connection, or not inside a protected call: an I/O error
+    /* Not our connection, or not inside an armed region: an I/O error
      * handler is not allowed to return, so hand it to whoever was
      * installed before us. */
     if (fg_io_prev != NULL)
@@ -215,6 +228,62 @@ static void fg_install_io_handler(void)
 
     if (prev != fg_io_error_handler)
         fg_io_prev = prev;
+}
+
+/* Arm a region: until fg_io_disarm(), a fatal I/O error on dpy longjmps
+ * to the most recent setjmp(fg_io_jmp) instead of exiting. */
+static void fg_io_arm(Display *dpy)
+{
+    fg_install_io_handler();
+    fg_io_display = dpy;
+    fg_io_armed = 1;
+}
+
+static void fg_io_disarm(void)
+{
+    fg_io_armed = 0;
+}
+
+/* XCloseDisplay inside an armed region.
+ *
+ * On a fault Xlib has not reached _XDisconnectDisplay yet -- it dies in
+ * the sync it does first -- so the descriptor is still open and ours to
+ * reclaim, while the struct is abandoned because a close cannot be
+ * retried. The recovery path reads fg_io_display rather than the
+ * parameter: a local written before setjmp() is indeterminate after a
+ * longjmp, a file static is not. */
+static void fg_close_display_guarded(Display *dpy)
+{
+    if (setjmp(fg_io_jmp) != 0) {
+        fg_io_disarm();
+        fg_close_connection_fd(fg_io_display);
+        return;
+    }
+    fg_io_arm(dpy);
+    XCloseDisplay(dpy);
+    fg_io_disarm();
+}
+
+/* Forget the cached connection.
+ *
+ * close_connection says whether XCloseDisplay may be attempted at all.
+ * It may not when the socket is shared with a parent process
+ * (post-fork), where the protocol write would corrupt the parent's
+ * stream, nor when the connection has just faulted, where Xlib is
+ * already mid-teardown. Everywhere else the close goes through the
+ * guarded path above rather than raw. */
+static void fg_drop_display(int close_connection)
+{
+    if (fg_display != NULL) {
+        if (close_connection)
+            fg_close_display_guarded(fg_display);
+        else
+            fg_close_connection_fd(fg_display);
+    }
+    fg_display = NULL;
+    free(fg_display_name);
+    fg_display_name = NULL;
+    fg_display_pid = 0;
 }
 
 /* Return the cached connection, opening one if needed.
@@ -249,12 +318,11 @@ static int fg_acquire_display(Display **out, int *reused)
     if (env != NULL) {
         name = fg_dup(env);
         if (name == NULL) {
-            XCloseDisplay(dpy);
+            fg_close_display_guarded(dpy);
             return FG_ERR_NOMEM;
         }
     }
 
-    fg_install_io_handler();
     fg_display = dpy;
     fg_display_name = name;
     fg_display_pid = getpid();
@@ -286,15 +354,14 @@ static int fg_try_once(fg_display_op op, void *ctx, int *reused)
         return rc;
 
     if (setjmp(fg_io_jmp) != 0) {
-        fg_io_armed = 0;
+        fg_io_disarm();
         fg_drop_display(0);
         return FG_ERR_LOST;
     }
 
-    fg_io_display = dpy;
-    fg_io_armed = 1;
+    fg_io_arm(dpy);
     rc = op(dpy, ctx);
-    fg_io_armed = 0;
+    fg_io_disarm();
     return rc;
 }
 

--- a/fastgrab/linux_x11/screenshot.c
+++ b/fastgrab/linux_x11/screenshot.c
@@ -116,9 +116,11 @@ static const char *fg_strerror(int code)
  *    to get subtly wrong, and both were: the handler has to be armed
  *    around *every* Xlib call on a connection that might be dead --
  *    XCloseDisplay included, since dropping a stale connection on a
- *    DISPLAY switch is itself I/O -- and it has to be (re)installed per
- *    armed region, because Xlib's handler is process-global and any
- *    other Xlib user can replace it between two of our calls.
+ *    DISPLAY switch is itself I/O -- and it has to be installed *and
+ *    removed* per armed region. Xlib's handler is process-global, so
+ *    leaving ours installed between calls both let another Xlib user
+ *    replace it unnoticed and let one chain to it, closing a delegation
+ *    loop that no I/O error could ever escape.
  *
  * Nothing tears the connection down at interpreter shutdown, on purpose.
  * The repo already avoids finalizer-ordering hazards (the wlr and
@@ -137,6 +139,10 @@ static pid_t fg_display_pid = 0;
  * _display_cache_info() below, which is how the tests observe that a
  * capture loop reuses one connection instead of opening one per frame. */
 static unsigned long fg_display_opens = 0;
+/* Unsolicited events thrown away since import. Read by the private
+ * _display_cache_info() so a test can tell a drained queue from a queue
+ * nothing ever arrived on. */
+static unsigned long fg_events_discarded = 0;
 
 /* strdup() is POSIX and this file is compiled with -std=c11; rather than
  * depend on which feature-test macros happen to be in force, duplicate
@@ -222,19 +228,33 @@ static int fg_io_error_handler(Display *dpy)
     exit(1);
 }
 
-static void fg_install_io_handler(void)
-{
-    XIOErrorHandler prev = XSetIOErrorHandler(fg_io_error_handler);
-
-    if (prev != fg_io_error_handler)
-        fg_io_prev = prev;
-}
-
 /* Arm a region: until fg_io_disarm(), a fatal I/O error on dpy longjmps
- * to the most recent setjmp(fg_io_jmp) instead of exiting. */
+ * to the most recent setjmp(fg_io_jmp) instead of exiting.
+ *
+ * The displaced handler is put back on the way out, so this one is
+ * installed only while a protected call is actually running. Staying
+ * installed between calls is what let a chain close into a loop: a
+ * third party installing a delegating handler in the gap would capture
+ * *this* handler as its predecessor, and the next arm would then record
+ * that wrapper as fg_io_prev -- two handlers each delegating to the
+ * other, and an I/O error on an unrelated connection bouncing between
+ * them forever instead of reaching the handler that was there first.
+ * Testing prev != ours only ever caught the direct case.
+ *
+ * Swapping in and out per region is safe because the GIL is held across
+ * the whole call and nothing inside a region runs Python, so no other
+ * Xlib user in this process can install a handler while we are swapped
+ * in. (A non-Python thread calling XSetIOErrorHandler in that window
+ * would have its install overwritten on disarm. That is a narrower race
+ * than the cycle it replaces, and Xlib's single global handler offers
+ * nothing better.)
+ *
+ * fg_io_display is deliberately not cleared here: the recovery path in
+ * fg_close_display_guarded() reads it straight after a fault to find
+ * the descriptor to reclaim. It is only ever compared while armed. */
 static void fg_io_arm(Display *dpy)
 {
-    fg_install_io_handler();
+    fg_io_prev = XSetIOErrorHandler(fg_io_error_handler);
     fg_io_display = dpy;
     fg_io_armed = 1;
 }
@@ -242,6 +262,35 @@ static void fg_io_arm(Display *dpy)
 static void fg_io_disarm(void)
 {
     fg_io_armed = 0;
+    XSetIOErrorHandler(fg_io_prev);
+    fg_io_prev = NULL;
+}
+
+/* Discard events the server sent that nobody asked for.
+ *
+ * MappingNotify reaches every client whatever its event mask, so any
+ * other client changing a keyboard or pointer mapping queues an event
+ * on this connection. The synchronous calls here pull those into Xlib's
+ * queue while waiting for their own replies, and nothing ever consumes
+ * them. A per-call connection reclaimed the queue at XCloseDisplay; a
+ * cached one grows for the life of the process -- worst in exactly the
+ * long-running recording loop this cache exists to speed up.
+ *
+ * QueuedAlready is a queue-length read and never a socket read, so this
+ * cannot block or fault; anything still in the socket buffer is pulled
+ * into the queue by the next call's reply processing and discarded
+ * then. It runs inside the armed region anyway, because that is where
+ * every Xlib call on this connection belongs. */
+static void fg_drain_events(Display *dpy)
+{
+    int queued = XEventsQueued(dpy, QueuedAlready);
+
+    while (queued-- > 0) {
+        XEvent event;
+
+        XNextEvent(dpy, &event);
+        fg_events_discarded++;
+    }
 }
 
 /* XCloseDisplay inside an armed region.
@@ -255,8 +304,15 @@ static void fg_io_disarm(void)
 static void fg_close_display_guarded(Display *dpy)
 {
     if (setjmp(fg_io_jmp) != 0) {
+        /* Read before disarming rather than after: the connection to
+         * reclaim is the one the handler faulted on, and depending on
+         * disarm leaving fg_io_display alone would be a trap for the
+         * next person to touch it. */
+        Display *faulted = fg_io_display;
+
         fg_io_disarm();
-        fg_close_connection_fd(fg_io_display);
+        if (faulted != NULL)
+            fg_close_connection_fd(faulted);
         return;
     }
     fg_io_arm(dpy);
@@ -361,6 +417,7 @@ static int fg_try_once(fg_display_op op, void *ctx, int *reused)
 
     fg_io_arm(dpy);
     rc = op(dpy, ctx);
+    fg_drain_events(dpy);
     fg_io_disarm();
     return rc;
 }
@@ -660,11 +717,18 @@ static PyObject *linux_x11_display_cache_info(PyObject *self, PyObject *args)
         if (name == NULL)
             return NULL;
     }
-    return Py_BuildValue("{s:O,s:N,s:k,s:l}",
+    /* QueuedAlready is a queue-length read, not a socket read: it does
+     * no I/O, so it needs no armed region and cannot fault. */
+    return Py_BuildValue("{s:O,s:N,s:k,s:l,s:l,s:k}",
                          "connected", fg_display != NULL ? Py_True : Py_False,
                          "display", name,
                          "opens", fg_display_opens,
-                         "pid", (long)fg_display_pid);
+                         "pid", (long)fg_display_pid,
+                         "queued",
+                         fg_display != NULL
+                             ? (long)XEventsQueued(fg_display, QueuedAlready)
+                             : 0L,
+                         "events_discarded", fg_events_discarded);
 }
 
 static PyObject *linux_x11_close_display(PyObject *self, PyObject *args)
@@ -686,9 +750,12 @@ static PyMethodDef linux_x11_methods[] = {
      "capture a screenshot using X11"},
     {"_display_cache_info", linux_x11_display_cache_info, METH_NOARGS,
      "private, for the tests: report the cached X connection as a dict "
-     "of connected / display / opens / pid. 'opens' counts connections "
-     "made since import, which is how a test tells connection reuse from "
-     "one connection per frame."},
+     "of connected / display / opens / pid / queued / events_discarded. "
+     "'opens' counts connections made since import, which is how a test "
+     "tells connection reuse from one connection per frame. 'queued' is "
+     "the unread event queue length and 'events_discarded' the running "
+     "total thrown away, which together tell a drained queue from one "
+     "nothing ever arrived on."},
     {"_close_display", linux_x11_close_display, METH_NOARGS,
      "private, for the tests: drop the cached X connection. The next "
      "call reconnects."},

--- a/fastgrab/linux_x11/screenshot.c
+++ b/fastgrab/linux_x11/screenshot.c
@@ -1,10 +1,21 @@
+/* Python.h before any standard header: CPython documents that
+ * requirement, and here it is load-bearing rather than stylistic.
+ * pyconfig.h is what defines _POSIX_C_SOURCE / _XOPEN_SOURCE for this
+ * translation unit, and glibc latches its feature-test macros in the
+ * first system header it sees. Included after <limits.h> — as it used
+ * to be — the macros arrive too late, the unit is built as strict ISO
+ * C11 (see -std=c11 in build.py), and the POSIX getpid()/close() the
+ * display cache below needs are never declared. */
+#include <Python.h>
+
 #include <limits.h>
+#include <setjmp.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
-#include <Python.h>
 #define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
 #include <numpy/arrayobject.h>
 
@@ -20,6 +31,9 @@
 #define FG_ERR_DEPTH    -4
 #define FG_ERR_CAPACITY -5
 #define FG_ERR_STRIDE   -6
+#define FG_ERR_GEOMETRY -7
+#define FG_ERR_LOST     -8
+#define FG_ERR_NOMEM    -9
 
 static const char *fg_strerror(int code)
 {
@@ -41,28 +55,389 @@ static const char *fg_strerror(int code)
     case FG_ERR_STRIDE:
         return "X server returned a row stride narrower than the "
                "requested width";
+    case FG_ERR_GEOMETRY:
+        return "could not read the size of the X root window";
+    case FG_ERR_LOST:
+        return "the X server closed the connection; the cached display "
+               "was dropped, so a later call will reconnect";
     default:
         return "unknown X11 error";
     }
 }
 
+/* ------------------------------------------------------------------ *
+ * Cached display connection
+ *
+ * Every entry point used to run XOpenDisplay(NULL) ... XCloseDisplay()
+ * around a single request, so a capture loop opened and tore down one X
+ * connection per frame. That is the churn behind issue #44: connecting
+ * costs an auth-file read, a socket connect and a full setup reply, all
+ * of which can fail transiently on a loaded machine, and the failure
+ * surfaces as "cannot open X display" on a server that is perfectly
+ * healthy.
+ *
+ * One connection is kept per process instead. Four things have to be
+ * true for that to be safe:
+ *
+ * 1. DISPLAY is re-read on every call and the cache is keyed on it, so a
+ *    caller that repoints DISPLAY gets a connection to the display it
+ *    just named rather than the one it named earlier. Unset and empty
+ *    are distinct keys: XOpenDisplay(NULL) is still what actually
+ *    resolves the name, so its own rules for both are preserved.
+ *
+ * 2. The GIL is held across the whole call, exactly as before this
+ *    change -- no Py_BEGIN_ALLOW_THREADS was here and none is added.
+ *    That is what makes a shared Display* safe without XInitThreads():
+ *    two Python threads cannot be inside libX11 on this connection at
+ *    the same time. XInitThreads() is deliberately not called. It has to
+ *    run before any other Xlib call process-wide, so a library cannot
+ *    honestly promise it, and calling it from an imported extension
+ *    changes locking for every other Xlib user in the process. Releasing
+ *    the GIL around XGetImage would be a real throughput win for
+ *    multi-threaded callers, but it needs that global opt-in plus
+ *    per-connection locking, and it is a separate change.
+ *
+ * 3. The owning pid is recorded. A connection inherited across fork()
+ *    is poisoned: parent and child hold descriptors onto one socket and
+ *    their requests interleave into a single protocol stream. A child
+ *    therefore abandons the inherited Display and connects afresh. It
+ *    must not XCloseDisplay() it -- that writes to the socket the parent
+ *    is still using -- so the Display struct is leaked once and only the
+ *    child's own descriptor is closed, which the parent never sees.
+ *
+ * 4. A dead connection cannot become a hard exit(). Xlib's default I/O
+ *    error handler prints and calls exit(); with a cached connection a
+ *    server that went away between two captures would meet that handler
+ *    instead of the clean XOpenDisplay-returned-NULL path it used to.
+ *    fg_io_error_handler() below longjmps back out instead, the dead
+ *    connection is dropped, and the call is retried once on a fresh one
+ *    so that a restarted server keeps behaving the way it did when every
+ *    call opened its own connection.
+ *
+ * Nothing tears the connection down at interpreter shutdown, on purpose.
+ * The repo already avoids finalizer-ordering hazards (the wlr and
+ * windows backends have no __del__, and tests/_run_pytest_clean_exit.py
+ * exists to os._exit past one), and an atexit hook or a module m_free
+ * would put an X round trip at an unpredictable point in teardown for no
+ * benefit: the kernel closes the socket and the server reaps the client.
+ * ------------------------------------------------------------------ */
+
+static Display *fg_display = NULL;
+/* Copy of DISPLAY as it was when fg_display was opened. NULL means the
+ * variable was unset, which is a different key from "" (set but empty). */
+static char *fg_display_name = NULL;
+static pid_t fg_display_pid = 0;
+/* Connections opened since import. Only read by the private
+ * _display_cache_info() below, which is how the tests observe that a
+ * capture loop reuses one connection instead of opening one per frame. */
+static unsigned long fg_display_opens = 0;
+
+/* strdup() is POSIX and this file is compiled with -std=c11; rather than
+ * depend on which feature-test macros happen to be in force, duplicate
+ * the few bytes by hand. */
+static char *fg_dup(const char *s)
+{
+    size_t n = strlen(s) + 1;
+    char *copy = malloc(n);
+
+    if (copy != NULL)
+        memcpy(copy, s, n);
+    return copy;
+}
+
+static int fg_display_name_matches(const char *env)
+{
+    if (env == NULL || fg_display_name == NULL)
+        return env == fg_display_name;  /* both unset, or exactly one */
+    return strcmp(env, fg_display_name) == 0;
+}
+
+/* Forget the cached connection.
+ *
+ * close_connection tells XCloseDisplay whether it may talk to the
+ * server. It may not when the socket is shared with a parent process
+ * (post-fork) or is already dead (I/O error): in both cases the protocol
+ * write would either corrupt someone else's stream or re-enter the I/O
+ * error path. The Display struct is then leaked -- once per fork and
+ * once per server death, never per call -- and only the descriptor is
+ * reclaimed. Closing our own descriptor sends nothing to the server and
+ * leaves the parent's copy of the socket untouched. */
+static void fg_drop_display(int close_connection)
+{
+    if (fg_display != NULL) {
+        if (close_connection) {
+            XCloseDisplay(fg_display);
+        } else {
+            int fd = ConnectionNumber(fg_display);
+            if (fd >= 0)
+                close(fd);
+        }
+    }
+    fg_display = NULL;
+    free(fg_display_name);
+    fg_display_name = NULL;
+    fg_display_pid = 0;
+}
+
+/* ------------------------------------------------------------------ *
+ * I/O error recovery
+ *
+ * Installed lazily, on the first successful connect, so merely importing
+ * fastgrab does not change process-global Xlib state. Re-installed on
+ * every connect so that a host application which set its own handler in
+ * the meantime is chained to rather than clobbered.
+ * ------------------------------------------------------------------ */
+
+static jmp_buf fg_io_jmp;
+static volatile int fg_io_armed = 0;
+static Display *fg_io_display = NULL;
+static XIOErrorHandler fg_io_prev = NULL;
+
+static int fg_io_error_handler(Display *dpy)
+{
+    if (fg_io_armed && dpy == fg_io_display) {
+        fg_io_armed = 0;
+        longjmp(fg_io_jmp, 1);  /* does not return */
+    }
+    /* Not our connection, or not inside a protected call: an I/O error
+     * handler is not allowed to return, so hand it to whoever was
+     * installed before us. */
+    if (fg_io_prev != NULL)
+        return fg_io_prev(dpy);
+    fprintf(stderr, "XIO: fatal IO error on X server \"%s\"\n",
+            DisplayString(dpy));
+    exit(1);
+}
+
+static void fg_install_io_handler(void)
+{
+    XIOErrorHandler prev = XSetIOErrorHandler(fg_io_error_handler);
+
+    if (prev != fg_io_error_handler)
+        fg_io_prev = prev;
+}
+
+/* Return the cached connection, opening one if needed.
+ *
+ * *reused says whether the returned connection was already open, which
+ * is what decides if a mid-call server death is worth retrying. */
+static int fg_acquire_display(Display **out, int *reused)
+{
+    const char *env = getenv("DISPLAY");
+    Display *dpy;
+    char *name = NULL;
+
+    *reused = 0;
+
+    if (fg_display != NULL) {
+        if (fg_display_pid != getpid())
+            fg_drop_display(0);
+        else if (!fg_display_name_matches(env))
+            fg_drop_display(1);
+    }
+
+    if (fg_display != NULL) {
+        *out = fg_display;
+        *reused = 1;
+        return FG_OK;
+    }
+
+    dpy = XOpenDisplay(NULL);
+    if (dpy == NULL)
+        return FG_ERR_DISPLAY;
+
+    if (env != NULL) {
+        name = fg_dup(env);
+        if (name == NULL) {
+            XCloseDisplay(dpy);
+            return FG_ERR_NOMEM;
+        }
+    }
+
+    fg_install_io_handler();
+    fg_display = dpy;
+    fg_display_name = name;
+    fg_display_pid = getpid();
+    fg_display_opens++;
+    *out = dpy;
+    return FG_OK;
+}
+
+typedef int (*fg_display_op)(Display *dpy, void *ctx);
+
+/* Run one operation on the cached connection, catching a server that
+ * dies underneath it. The setjmp target has to live in the frame that
+ * is still active when the handler fires, which is this one.
+ *
+ * Nothing written before or after setjmp() is read on the longjmp path
+ * -- it drops the connection through file statics and returns a
+ * constant -- so no local needs to be volatile. Building with -Wextra
+ * still reports -Wclobbered here once fg_acquire_display() is inlined:
+ * that is gcc flagging a value that is live across the setjmp, not one
+ * this code reads afterwards. The project's own flags (-Wall
+ * -Wsign-compare) are clean. */
+static int fg_try_once(fg_display_op op, void *ctx, int *reused)
+{
+    Display *dpy;
+    int rc;
+
+    rc = fg_acquire_display(&dpy, reused);
+    if (rc != FG_OK)
+        return rc;
+
+    if (setjmp(fg_io_jmp) != 0) {
+        fg_io_armed = 0;
+        fg_drop_display(0);
+        return FG_ERR_LOST;
+    }
+
+    fg_io_display = dpy;
+    fg_io_armed = 1;
+    rc = op(dpy, ctx);
+    fg_io_armed = 0;
+    return rc;
+}
+
+static int fg_call_with_display(fg_display_op op, void *ctx)
+{
+    int reused = 0;
+    int rc = fg_try_once(op, ctx, &reused);
+
+    /* A connection that was already open can have gone stale while it
+     * sat idle -- the server restarted, the session ended. Before this
+     * cache existed every call connected from scratch and simply saw the
+     * new server, so reconnect once and repeat the request rather than
+     * making callers handle a failure they never used to see. Only a
+     * reused connection is retried, so a genuinely dead server cannot
+     * loop, and every operation here is a read: repeating one is safe. */
+    if (rc == FG_ERR_LOST && reused)
+        rc = fg_try_once(op, ctx, &reused);
+    return rc;
+}
+
+/* ------------------------------------------------------------------ *
+ * Operations
+ * ------------------------------------------------------------------ */
+
+/* Ask the server for the root window's current size.
+ *
+ * Not ScreenOfDisplay()->width/height: those come from the connection
+ * setup and are only refreshed by an Xlib client that processes RandR
+ * events, which this one does not. With a per-call connection reading
+ * them was accurate by accident; with a cached one they would freeze at
+ * whatever the screen measured when fastgrab first connected. A screen
+ * that then shrank would still pass the bounds check below and reach
+ * XGetImage as a BadMatch -- delivered to Xlib's default error handler,
+ * which exits the interpreter. One extra round trip is the price of the
+ * bounds check staying true, and it keeps resolution() reporting the
+ * live size the way it did before. */
+static int fg_root_size(Display *dpy, int *width, int *height)
+{
+    Window root = RootWindow(dpy, DefaultScreen(dpy));
+    Window root_return;
+    int x, y;
+    unsigned int w, h, border, depth;
+
+    if (!XGetGeometry(dpy, root, &root_return, &x, &y, &w, &h,
+                      &border, &depth))
+        return FG_ERR_GEOMETRY;
+    if (w > (unsigned int)INT_MAX || h > (unsigned int)INT_MAX)
+        return FG_ERR_GEOMETRY;
+
+    *width = (int)w;
+    *height = (int)h;
+    return FG_OK;
+}
+
+/* DefaultScreen(), not 0: capture and its bounds check both use
+ * RootWindow(display, DefaultScreen(display)), and on a DISPLAY of the
+ * form :N.1 those are different screens. Reporting one screen's size
+ * while capturing another makes the high-level bbox check disagree with
+ * what the server will actually allow. (A DISPLAY that names a different
+ * screen is also a different cache key, so switching between them
+ * reconnects rather than answering from the wrong connection.) */
+static int fg_op_resolution(Display *dpy, void *ctx)
+{
+    int *resolution = (int *)ctx;
+
+    return fg_root_size(dpy, &resolution[0], &resolution[1]);
+}
+
 static int screen_resolution(int *resolution)
 {
-    Display *display;
-    Screen *screen;
+    return fg_call_with_display(fg_op_resolution, resolution);
+}
 
-    display = XOpenDisplay(NULL);
-    if (display == NULL)
-        return FG_ERR_DISPLAY;
-    /* DefaultScreen(), not 0: capture and its bounds check both use
-     * RootWindow(display, DefaultScreen(display)), and on a DISPLAY of
-     * the form :N.1 those are different screens. Reporting one screen's
-     * size while capturing another makes the high-level bbox check
-     * disagree with what the server will actually allow. */
-    screen = ScreenOfDisplay(display, DefaultScreen(display));
-    resolution[0] = screen->width;
-    resolution[1] = screen->height;
-    XCloseDisplay(display);
+struct fg_shot_ctx {
+    int origin_x;
+    int origin_y;
+    int width;
+    int height;
+    uint8_t *data;
+    size_t capacity;
+};
+
+static int fg_op_screenshot(Display *dpy, void *ctx)
+{
+    struct fg_shot_ctx *req = (struct fg_shot_ctx *)ctx;
+    XImage *img;
+    int screen_width, screen_height;
+    int rc;
+
+    rc = fg_root_size(dpy, &screen_width, &screen_height);
+    if (rc != FG_OK)
+        return rc;
+
+    /* Written as subtractions so a large origin cannot overflow int. */
+    if (req->origin_x < 0 || req->origin_y < 0 ||
+        req->origin_x > screen_width - req->width ||
+        req->origin_y > screen_height - req->height)
+        return FG_ERR_BOUNDS;
+
+    img = XGetImage(dpy,
+                    RootWindow(dpy, DefaultScreen(dpy)),
+                    req->origin_x, req->origin_y, req->width, req->height,
+                    AllPlanes, ZPixmap);
+    if (img == NULL)
+        return FG_ERR_GETIMAGE;
+
+    /* ZPixmap on a 32-bit visual is laid out B,G,R,A on little-endian
+     * hosts, which is the byte order the Python side promises. Anything
+     * else would be copied as the wrong number of bytes per pixel and
+     * handed back as if it were BGRA. */
+    if (img->bits_per_pixel != 32) {
+        XDestroyImage(img);
+        return FG_ERR_DEPTH;
+    }
+
+    const size_t row_bytes = (size_t)req->width * 4;
+    const size_t nbytes = row_bytes * (size_t)req->height;
+
+    /* Defence in depth: the caller's buffer was already checked against
+     * the requested shape, but the size actually copied is derived from
+     * what the server returned. */
+    if (nbytes > req->capacity) {
+        XDestroyImage(img);
+        return FG_ERR_CAPACITY;
+    }
+    if ((size_t)img->bytes_per_line < row_bytes) {
+        XDestroyImage(img);
+        return FG_ERR_STRIDE;
+    }
+
+    if ((size_t)img->bytes_per_line == row_bytes) {
+        memcpy(req->data, img->data, nbytes);
+    } else {
+        /* The server is free to pad rows; copying straight through would
+         * shear the image by the padding on every row. */
+        int row;
+        for (row = 0; row < req->height; row++)
+            memcpy(req->data + (size_t)row * row_bytes,
+                   img->data + (size_t)row * (size_t)img->bytes_per_line,
+                   row_bytes);
+    }
+
+    XDestroyImage(img);
     return FG_OK;
 }
 
@@ -73,117 +448,67 @@ static int screenshot(const int origin_x,
                       uint8_t *data,
                       const size_t capacity)
 {
-    XImage *img;
-    Display *display;
-    Screen *screen;
+    struct fg_shot_ctx req;
 
-    /* Bounds are checked here rather than left to the server: a region
-     * that reaches outside the root window is a BadMatch, and the NULL
-     * check below cannot catch it. X protocol errors are delivered
-     * asynchronously to Xlib's *default error handler*, which prints a
-     * diagnostic and calls exit() -- the interpreter dies with no
-     * exception and no traceback. The public API validates too, but
-     * this entry point is reachable directly, and
+    /* Bounds are checked here and in fg_op_screenshot rather than left
+     * to the server: a region that reaches outside the root window is a
+     * BadMatch, and the NULL check on XGetImage cannot catch it. X
+     * protocol errors are delivered asynchronously to Xlib's *default
+     * error handler*, which prints a diagnostic and calls exit() -- the
+     * interpreter dies with no exception and no traceback. The public
+     * API validates too, but this entry point is reachable directly, and
      * examples/low_level_api_screenshot.py promotes exactly that. */
     if (width <= 0 || height <= 0)
         return FG_ERR_BOUNDS;
 
-    display = XOpenDisplay(NULL);
-    if (display == NULL)
-        return FG_ERR_DISPLAY;
+    req.origin_x = origin_x;
+    req.origin_y = origin_y;
+    req.width = width;
+    req.height = height;
+    req.data = data;
+    req.capacity = capacity;
 
-    screen = ScreenOfDisplay(display, DefaultScreen(display));
-    /* Written as subtractions so a large origin cannot overflow int. */
-    if (origin_x < 0 || origin_y < 0 ||
-        origin_x > screen->width - width ||
-        origin_y > screen->height - height) {
-        XCloseDisplay(display);
-        return FG_ERR_BOUNDS;
-    }
+    return fg_call_with_display(fg_op_screenshot, &req);
+}
 
-    img = XGetImage(display,
-                    RootWindow(display, DefaultScreen(display)),
-                    origin_x, origin_y, width, height,
-                    AllPlanes, ZPixmap);
-    if (img == NULL) {
-        XCloseDisplay(display);
+static int fg_op_bytes_per_pixel(Display *dpy, void *ctx)
+{
+    int *bpp = (int *)ctx;
+    XImage *img = XGetImage(dpy,
+                            RootWindow(dpy, DefaultScreen(dpy)),
+                            0, 0, 1, 1,
+                            AllPlanes, ZPixmap);
+
+    if (img == NULL)
         return FG_ERR_GETIMAGE;
-    }
-
-    /* ZPixmap on a 32-bit visual is laid out B,G,R,A on little-endian
-     * hosts, which is the byte order the Python side promises. Anything
-     * else would be copied as the wrong number of bytes per pixel and
-     * handed back as if it were BGRA. */
-    if (img->bits_per_pixel != 32) {
-        XDestroyImage(img);
-        XCloseDisplay(display);
-        return FG_ERR_DEPTH;
-    }
-
-    const size_t row_bytes = (size_t)width * 4;
-    const size_t nbytes = row_bytes * (size_t)height;
-
-    /* Defence in depth: the caller's buffer was already checked against
-     * the requested shape, but the size actually copied is derived from
-     * what the server returned. */
-    if (nbytes > capacity) {
-        XDestroyImage(img);
-        XCloseDisplay(display);
-        return FG_ERR_CAPACITY;
-    }
-    if ((size_t)img->bytes_per_line < row_bytes) {
-        XDestroyImage(img);
-        XCloseDisplay(display);
-        return FG_ERR_STRIDE;
-    }
-
-    if ((size_t)img->bytes_per_line == row_bytes) {
-        memcpy(data, img->data, nbytes);
-    } else {
-        /* The server is free to pad rows; copying straight through would
-         * shear the image by the padding on every row. */
-        int row;
-        for (row = 0; row < height; row++)
-            memcpy(data + (size_t)row * row_bytes,
-                   img->data + (size_t)row * (size_t)img->bytes_per_line,
-                   row_bytes);
-    }
-
+    *bpp = img->bits_per_pixel / BITS_PER_BYTE;
     XDestroyImage(img);
-    XCloseDisplay(display);
     return FG_OK;
 }
 
 static int bytes_per_pixel(int *bpp)
 {
-    XImage *img;
-    Display *display;
+    return fg_call_with_display(fg_op_bytes_per_pixel, bpp);
+}
 
-    display = XOpenDisplay(NULL);
-    if (display == NULL)
-        return FG_ERR_DISPLAY;
-    img = XGetImage(display,
-                    RootWindow(display, DefaultScreen(display)),
-                    0, 0, 1, 1,
-                    AllPlanes, ZPixmap);
-    if (img == NULL) {
-        XCloseDisplay(display);
-        return FG_ERR_GETIMAGE;
-    }
-    *bpp = img->bits_per_pixel / BITS_PER_BYTE;
-    XDestroyImage(img);
-    XCloseDisplay(display);
-    return FG_OK;
+/* ------------------------------------------------------------------ *
+ * Python entry points
+ * ------------------------------------------------------------------ */
+
+static PyObject *fg_raise(int rc)
+{
+    if (rc == FG_ERR_NOMEM)
+        return PyErr_NoMemory();
+    PyErr_SetString(PyExc_RuntimeError, fg_strerror(rc));
+    return NULL;
 }
 
 static PyObject *linux_x11_screen_resolution(PyObject *self, PyObject *args)
 {
     int resolution[2];
     int rc = screen_resolution(resolution);
-    if (rc != FG_OK) {
-        PyErr_SetString(PyExc_RuntimeError, fg_strerror(rc));
-        return NULL;
-    }
+    if (rc != FG_OK)
+        return fg_raise(rc);
     return Py_BuildValue("(ii)", resolution[0], resolution[1]);
 }
 
@@ -191,10 +516,8 @@ static PyObject *linux_x11_bytes_per_pixel(PyObject *self, PyObject *args)
 {
     int bpp;
     int rc = bytes_per_pixel(&bpp);
-    if (rc != FG_OK) {
-        PyErr_SetString(PyExc_RuntimeError, fg_strerror(rc));
-        return NULL;
-    }
+    if (rc != FG_OK)
+        return fg_raise(rc);
     return PyLong_FromLong(bpp);
 }
 
@@ -253,9 +576,36 @@ static PyObject *linux_x11_screenshot(PyObject *self, PyObject *args)
                     (uint8_t *)PyArray_DATA(img),
                     (size_t)PyArray_NBYTES(img));
 
-    if (rc != FG_OK) {
-        PyErr_SetString(PyExc_RuntimeError, fg_strerror(rc));
-        return NULL;
+    if (rc != FG_OK)
+        return fg_raise(rc);
+    Py_RETURN_NONE;
+}
+
+static PyObject *linux_x11_display_cache_info(PyObject *self, PyObject *args)
+{
+    PyObject *name;
+
+    if (fg_display_name == NULL) {
+        name = Py_None;
+        Py_INCREF(name);
+    } else {
+        name = PyUnicode_FromString(fg_display_name);
+        if (name == NULL)
+            return NULL;
+    }
+    return Py_BuildValue("{s:O,s:N,s:k,s:l}",
+                         "connected", fg_display != NULL ? Py_True : Py_False,
+                         "display", name,
+                         "opens", fg_display_opens,
+                         "pid", (long)fg_display_pid);
+}
+
+static PyObject *linux_x11_close_display(PyObject *self, PyObject *args)
+{
+    if (fg_display != NULL) {
+        /* Only talk to the server if this process is the one that
+         * connected; a child that inherited the connection must not. */
+        fg_drop_display(fg_display_pid == getpid());
     }
     Py_RETURN_NONE;
 }
@@ -267,6 +617,14 @@ static PyMethodDef linux_x11_methods[] = {
      "return the number of bytes per pixel"},
     {"screenshot", linux_x11_screenshot, METH_VARARGS,
      "capture a screenshot using X11"},
+    {"_display_cache_info", linux_x11_display_cache_info, METH_NOARGS,
+     "private, for the tests: report the cached X connection as a dict "
+     "of connected / display / opens / pid. 'opens' counts connections "
+     "made since import, which is how a test tells connection reuse from "
+     "one connection per frame."},
+    {"_close_display", linux_x11_close_display, METH_NOARGS,
+     "private, for the tests: drop the cached X connection. The next "
+     "call reconnects."},
     {NULL, NULL, 0, NULL}
 };
 

--- a/tests/test_x11_lowlevel.py
+++ b/tests/test_x11_lowlevel.py
@@ -12,6 +12,7 @@ import os
 import shutil
 import subprocess
 import sys
+import time
 
 import numpy
 import pytest
@@ -414,17 +415,32 @@ def test_a_forked_child_connects_for_itself():
     _linux_x11.resolution()
 
 
+def _display_number_in_use(number):
+    # Both artefacts matter: Xvfb unlinks its socket *and* its lock file
+    # on a clean exit, and leaves both behind when it is SIGKILLed.
+    return (os.path.exists("/tmp/.X11-unix/X%d" % number)
+            or os.path.exists("/tmp/.X%d-lock" % number))
+
+
 def _free_display_numbers(count):
     numbers = []
     for number in range(90, 130):
-        if os.path.exists("/tmp/.X11-unix/X%d" % number):
-            continue
-        if os.path.exists("/tmp/.X%d-lock" % number):
+        if _display_number_in_use(number):
             continue
         numbers.append(number)
         if len(numbers) == count:
             return numbers
     return None
+
+
+def _displays_still_in_use(numbers, timeout=15.0):
+    """Bounded wait for the disposable servers to release their numbers."""
+    deadline = time.time() + timeout
+    while True:
+        still = [n for n in numbers if _display_number_in_use(n)]
+        if not still or time.time() > deadline:
+            return still
+        time.sleep(0.1)
 
 
 def _run_x_fault_script(script, displays=1, timeout=180):
@@ -447,59 +463,141 @@ def _run_x_fault_script(script, displays=1, timeout=180):
         [sys.executable, "-c", script] + [":%d" % n for n in numbers],
         capture_output=True, text=True, timeout=timeout,
     )
-    report = "exit={}\nstdout:\n{}\nstderr:\n{}".format(
-        result.returncode, result.stdout, result.stderr,
+    leaked = _displays_still_in_use(numbers)
+    report = "exit={}\nstdout:\n{}\nstderr:\n{}\nleaked displays: {}".format(
+        result.returncode, result.stdout, result.stderr, leaked,
     )
+    # A surviving X server fails nothing by itself -- it just keeps a
+    # display number. Once the pool is used up these tests start
+    # skipping, and a skipped test reads as green, which is the exact
+    # failure mode this whole change exists to remove. Fail loudly
+    # instead. The report carries the run's own output either way, so
+    # this assertion firing first never hides the real problem.
+    assert not leaked, report
     return result, report
 
 
-# Run out-of-process on purpose. The failure this guards against is the
-# interpreter *exiting*, which an in-process test cannot report — it
-# would take the whole pytest session down with it. Out here a
-# regression shows up as a non-zero exit status plus Xlib's "XIO: fatal
-# IO error" on stderr, both of which the assertion prints.
-_DEAD_SERVER_SCRIPT = r'''
+# Shared by every fault-injection script below. Each one starts throwaway
+# X servers, and the three ways that goes wrong are all lifecycle bugs
+# rather than bugs in what is being tested, so they are solved once here:
+#
+#   * a server must be waited for before anything connects to it, or a
+#     one-shot XOpenDisplay races Xvfb's startup and fails against a
+#     perfectly correct extension;
+#   * a server must be SIGTERMed and reaped, not SIGKILLed, or it cannot
+#     unlink its socket and lock file and the display number looks
+#     occupied to every later run;
+#   * every exit path must clean up -- including os._exit() from inside
+#     an X I/O error handler, which cannot return and so cannot rely on
+#     a finally block.
+_XVFB_PRELUDE = r'''
 import os
 import subprocess
 import sys
 import time
 
-import numpy
-
 from fastgrab import _linux_x11
 
-display = sys.argv[1]
-server = subprocess.Popen(
-    ["Xvfb", display, "-screen", "0", "320x240x24", "-ac"],
-    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-)
-os.environ["DISPLAY"] = display
-try:
-    deadline = time.time() + 15.0
-    while True:
+_servers = []
+
+
+def say(text):
+    # os.write rather than print: os._exit() does not flush Python's
+    # buffers, and half these scripts exit from inside an X I/O error
+    # handler.
+    os.write(1, (text + "\n").encode())
+
+
+def socket_path(display):
+    return "/tmp/.X11-unix/X" + display.lstrip(":").split(".")[0]
+
+
+def start(display):
+    proc = subprocess.Popen(
+        ["Xvfb", display, "-screen", "0", "320x240x24", "-ac"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    _servers.append(proc)
+    return proc
+
+
+def wait_for_socket(display, timeout=20.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if os.path.exists(socket_path(display)):
+            return True
+        time.sleep(0.05)
+    return False
+
+
+def wait_for_extension(display, timeout=20.0):
+    """Bounded wait until the extension can talk to `display`."""
+    os.environ["DISPLAY"] = display
+    deadline = time.time() + timeout
+    while time.time() < deadline:
         try:
-            _linux_x11.resolution()
-            break
+            return _linux_x11.resolution()
         except RuntimeError:
-            if time.time() > deadline:
-                print("SETUP-FAILED: Xvfb never became reachable")
-                raise SystemExit(2)
             time.sleep(0.05)
+    return None
+
+
+def stop(proc, timeout=15.0):
+    """Terminate and reap; SIGKILL only as a bounded fallback.
+
+    SIGTERM lets Xvfb unlink its socket and lock file. SIGKILL does not,
+    and the leftovers make that display number look occupied to every
+    later run.
+    """
+    if proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            try:
+                proc.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                pass
+    else:
+        proc.wait()
+
+
+def cleanup():
+    while _servers:
+        stop(_servers.pop())
+
+
+def finish(code, *messages):
+    """The one exit path. Nothing may leave a server behind."""
+    for message in messages:
+        say(message)
+    cleanup()
+    os._exit(code)
+'''
+
+
+_DEAD_SERVER_SCRIPT = _XVFB_PRELUDE + r'''
+import numpy
+
+display = sys.argv[1]
+server = start(display)
+try:
+    if not wait_for_socket(display) or wait_for_extension(display) is None:
+        finish(2, "SETUP-FAILED: Xvfb never became reachable")
 
     buf = numpy.zeros((16, 16, 4), "uint8")
-    # Every one of these arms a region and reinstalls the handler. If
-    # reinstalling ever recorded the handler as its own predecessor, a
+    # Every one of these arms a region and installs the handler. If
+    # installing ever recorded the handler as its own predecessor, a
     # fault would recurse instead of longjmping; 50 rounds makes that
     # show up as a crash rather than a pass.
     for _ in range(50):
         _linux_x11.screenshot(0, 0, buf)
     live = _linux_x11._display_cache_info()
     if not (live["connected"] and live["display"] == display):
-        print("SETUP-FAILED: not connected to the private server:", live)
-        raise SystemExit(2)
+        finish(2, "SETUP-FAILED: not connected to the private server: %r" % live)
 
-    server.terminate()
-    server.wait(timeout=15)
+    stop(server)
     time.sleep(0.2)
 
     # The cached connection is now a dead socket. Xlib's default I/O
@@ -509,16 +607,12 @@ try:
     except RuntimeError as exc:
         dead = _linux_x11._display_cache_info()
         if dead["connected"]:
-            print("KEPT-DEAD-CONNECTION:", dead)
-            raise SystemExit(3)
-        print("RAISED:", exc)
-        print("SURVIVED")
+            finish(3, "KEPT-DEAD-CONNECTION: %r" % dead)
+        finish(0, "RAISED: %s" % exc, "SURVIVED")
     else:
-        print("NO-ERROR: captured from a server that is gone")
-        raise SystemExit(3)
+        finish(3, "NO-ERROR: captured from a server that is gone")
 finally:
-    if server.poll() is None:
-        server.kill()
+    cleanup()
 '''
 
 
@@ -554,51 +648,28 @@ def test_a_dead_server_raises_instead_of_exiting_the_interpreter():
 # --------------------------------------------------------------------
 
 
-_SWITCHED_DISPLAY_SCRIPT = r'''
-import os
-import subprocess
-import sys
-import time
-
-from fastgrab import _linux_x11
-
+_SWITCHED_DISPLAY_SCRIPT = _XVFB_PRELUDE + r'''
 dead_display, live_display = sys.argv[1], sys.argv[2]
-
-
-def start(display):
-    return subprocess.Popen(
-        ["Xvfb", display, "-screen", "0", "320x240x24", "-ac"],
-        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-    )
-
-
-def connect(display):
-    os.environ["DISPLAY"] = display
-    deadline = time.time() + 15.0
-    while True:
-        try:
-            return _linux_x11.resolution()
-        except RuntimeError:
-            if time.time() > deadline:
-                print("SETUP-FAILED: %s never became reachable" % display)
-                raise SystemExit(2)
-            time.sleep(0.05)
-
 
 dead = start(dead_display)
 live = start(live_display)
 try:
+    for display in (dead_display, live_display):
+        if not wait_for_socket(display):
+            finish(2, "SETUP-FAILED: %s never appeared" % display)
+
     # Touch the survivor first so both servers are known good, then
     # leave the cache pointing at the one about to be killed.
-    connect(live_display)
-    connect(dead_display)
+    if wait_for_extension(live_display) is None:
+        finish(2, "SETUP-FAILED: %s never became reachable" % live_display)
+    if wait_for_extension(dead_display) is None:
+        finish(2, "SETUP-FAILED: %s never became reachable" % dead_display)
+
     cached = _linux_x11._display_cache_info()
     if cached["display"] != dead_display or not cached["connected"]:
-        print("SETUP-FAILED: cache holds", cached)
-        raise SystemExit(2)
+        finish(2, "SETUP-FAILED: cache holds %r" % cached)
 
-    dead.terminate()
-    dead.wait(timeout=15)
+    stop(dead)
     time.sleep(0.2)
 
     # Now name the healthy display. The cache has to drop the stale
@@ -609,14 +680,10 @@ try:
     size = _linux_x11.resolution()
     after = _linux_x11._display_cache_info()
     if not after["connected"] or after["display"] != live_display:
-        print("WRONG-DISPLAY:", after)
-        raise SystemExit(3)
-    print("SWITCHED: %r on %s" % (size, after["display"]))
-    print("SURVIVED")
+        finish(3, "WRONG-DISPLAY: %r" % after)
+    finish(0, "SWITCHED: %r on %s" % (size, after["display"]), "SURVIVED")
 finally:
-    for proc in (dead, live):
-        if proc.poll() is None:
-            proc.kill()
+    cleanup()
 '''
 
 
@@ -637,50 +704,30 @@ def test_switching_away_from_a_dead_display_does_not_exit():
     assert "SWITCHED:" in result.stdout, report
 
 
-_STOLEN_HANDLER_SCRIPT = r'''
+_STOLEN_HANDLER_SCRIPT = _XVFB_PRELUDE + r'''
 import ctypes
-import os
-import subprocess
-import sys
-import time
 
 import numpy
 
-from fastgrab import _linux_x11
-
 display = sys.argv[1]
-server = subprocess.Popen(
-    ["Xvfb", display, "-screen", "0", "320x240x24", "-ac"],
-    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-)
-os.environ["DISPLAY"] = display
+server = start(display)
 try:
-    deadline = time.time() + 15.0
-    while True:
-        try:
-            _linux_x11.resolution()
-            break
-        except RuntimeError:
-            if time.time() > deadline:
-                print("SETUP-FAILED: Xvfb never became reachable")
-                raise SystemExit(2)
-            time.sleep(0.05)
+    if not wait_for_socket(display) or wait_for_extension(display) is None:
+        finish(2, "SETUP-FAILED: Xvfb never became reachable")
 
     # Another Xlib user in the process clears the process-global I/O
     # error handler -- which is what a toolkit does when it tears its
     # own connection down, and Tk runs in-process under recording/gui.
-    # The extension is now covered by Xlib's fatal default unless it
-    # reinstalls for every protected call rather than once per connect.
+    # The extension is covered by Xlib's fatal default unless it
+    # installs for every protected call rather than once per connect.
     libX11 = ctypes.CDLL("libX11.so.6")
     libX11.XSetIOErrorHandler.restype = ctypes.c_void_p
     libX11.XSetIOErrorHandler.argtypes = [ctypes.c_void_p]
     stolen_from = libX11.XSetIOErrorHandler(None)
     if not stolen_from:
-        print("SETUP-FAILED: there was no handler installed to displace")
-        raise SystemExit(2)
+        finish(2, "SETUP-FAILED: there was no handler installed to displace")
 
-    server.terminate()
-    server.wait(timeout=15)
+    stop(server)
     time.sleep(0.2)
 
     buf = numpy.zeros((16, 16, 4), "uint8")
@@ -689,24 +736,18 @@ try:
     except RuntimeError as exc:
         dead = _linux_x11._display_cache_info()
         if dead["connected"]:
-            print("KEPT-DEAD-CONNECTION:", dead)
-            raise SystemExit(3)
-        print("RAISED:", exc)
+            finish(3, "KEPT-DEAD-CONNECTION: %r" % dead)
         # Surviving is not proof on its own -- reclaim the handler again
         # and check the extension had put the same function back, rather
         # than having got lucky some other way.
         reinstalled = libX11.XSetIOErrorHandler(None)
         if reinstalled != stolen_from:
-            print("NOT-REINSTALLED: %r vs %r" % (reinstalled, stolen_from))
-            raise SystemExit(3)
-        print("REINSTALLED")
-        print("SURVIVED")
+            finish(3, "NOT-REINSTALLED: %r vs %r" % (reinstalled, stolen_from))
+        finish(0, "RAISED: %s" % exc, "REINSTALLED", "SURVIVED")
     else:
-        print("NO-ERROR: captured from a server that is gone")
-        raise SystemExit(3)
+        finish(3, "NO-ERROR: captured from a server that is gone")
 finally:
-    if server.poll() is None:
-        server.kill()
+    cleanup()
 '''
 
 
@@ -781,14 +822,8 @@ def test_unread_events_do_not_pile_up_on_the_cached_connection():
     )
 
 
-_HANDLER_CYCLE_SCRIPT = r'''
+_HANDLER_CYCLE_SCRIPT = _XVFB_PRELUDE + r'''
 import ctypes
-import os
-import subprocess
-import sys
-import time
-
-from fastgrab import _linux_x11
 
 our_display, other_display = sys.argv[1], sys.argv[2]
 
@@ -802,16 +837,14 @@ libX11.XSync.restype = ctypes.c_int
 libX11.XSync.argtypes = [ctypes.c_void_p, ctypes.c_int]
 
 
-def say(text):
-    os.write(1, (text + "\n").encode())
-
-
 # The handler that was there first. Reaching it is the whole point: a
 # delegation chain has to end somewhere.
 @HANDLER
 def base_handler(dpy):
-    say("BASE-REACHED")
-    os._exit(0)
+    # finish() rather than a bare os._exit: an X I/O error handler must
+    # not return, so this is the only chance to stop the servers this
+    # script started. The successful path used to leak one here.
+    finish(0, "BASE-REACHED")
     return 0
 
 
@@ -825,42 +858,36 @@ entries = [0]
 def delegating_handler(dpy):
     entries[0] += 1
     if entries[0] > 1:
-        say("CYCLE: delegation came back round to this handler")
-        os._exit(9)
+        finish(9, "CYCLE: delegation came back round to this handler")
     displaced_by_us(dpy)
-    say("UNREACHABLE: a delegate returned")
-    os._exit(4)
+    finish(4, "UNREACHABLE: a delegate returned")
     return 0
-
-
-def start(display):
-    return subprocess.Popen(
-        ["Xvfb", display, "-screen", "0", "320x240x24", "-ac"],
-        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-    )
 
 
 ours = start(our_display)
 other = start(other_display)
 try:
+    for display in (our_display, other_display):
+        if not wait_for_socket(display):
+            finish(2, "SETUP-FAILED: %s never appeared" % display)
+
     libX11.XSetIOErrorHandler(base_handler)
 
-    os.environ["DISPLAY"] = our_display
-    deadline = time.time() + 15.0
-    while True:
-        try:
-            _linux_x11.resolution()
-            break
-        except RuntimeError:
-            if time.time() > deadline:
-                say("SETUP-FAILED: %s never became reachable" % our_display)
-                raise SystemExit(2)
-            time.sleep(0.05)
+    if wait_for_extension(our_display) is None:
+        finish(2, "SETUP-FAILED: %s never became reachable" % our_display)
 
-    unrelated = libX11.XOpenDisplay(other_display.encode())
+    # Bounded retry rather than one shot: the socket existing does not
+    # quite mean the server is accepting yet, and a lost race here would
+    # fail the test against a correct extension.
+    unrelated = None
+    deadline = time.time() + 20.0
+    while time.time() < deadline:
+        unrelated = libX11.XOpenDisplay(other_display.encode())
+        if unrelated:
+            break
+        time.sleep(0.05)
     if not unrelated:
-        say("SETUP-FAILED: could not open %s" % other_display)
-        raise SystemExit(2)
+        finish(2, "SETUP-FAILED: could not open %s" % other_display)
 
     # A third party installs its delegating handler between two
     # captures. Whatever it displaces becomes its predecessor.
@@ -871,19 +898,15 @@ try:
     # its own predecessor and closes the loop.
     _linux_x11.resolution()
 
-    other.terminate()
-    other.wait(timeout=15)
+    stop(other)
     time.sleep(0.2)
 
     # A fatal I/O error on a connection that has nothing to do with the
     # cache. It must reach base_handler.
     libX11.XSync(unrelated, 0)
-    say("NO-FAULT: the dead connection did not raise an I/O error")
-    raise SystemExit(5)
+    finish(5, "NO-FAULT: the dead connection did not raise an I/O error")
 finally:
-    for proc in (ours, other):
-        if proc.poll() is None:
-            proc.kill()
+    cleanup()
 '''
 
 

--- a/tests/test_x11_lowlevel.py
+++ b/tests/test_x11_lowlevel.py
@@ -414,14 +414,43 @@ def test_a_forked_child_connects_for_itself():
     _linux_x11.resolution()
 
 
-def _free_display_number():
-    for number in range(90, 110):
+def _free_display_numbers(count):
+    numbers = []
+    for number in range(90, 130):
         if os.path.exists("/tmp/.X11-unix/X%d" % number):
             continue
         if os.path.exists("/tmp/.X%d-lock" % number):
             continue
-        return number
+        numbers.append(number)
+        if len(numbers) == count:
+            return numbers
     return None
+
+
+def _run_x_fault_script(script, displays=1, timeout=180):
+    """Run a fault-injection script out of process, return (result, report).
+
+    Out of process because every failure these guard against is the
+    interpreter *exiting*: in process it would take the pytest session
+    down with it, and an assertion that cannot tell exit-1 from a raised
+    exception is not a test of this at all. Here a regression shows up
+    as a non-zero exit status plus Xlib's "XIO: fatal IO error" (or "X
+    connection to ... broken") on stderr, which the report prints.
+    """
+    if not shutil.which("Xvfb"):
+        pytest.skip("Xvfb is not installed; cannot run a disposable X server")
+    numbers = _free_display_numbers(displays)
+    if numbers is None:
+        pytest.skip("not enough free X display numbers for disposable servers")
+
+    result = subprocess.run(
+        [sys.executable, "-c", script] + [":%d" % n for n in numbers],
+        capture_output=True, text=True, timeout=timeout,
+    )
+    report = "exit={}\nstdout:\n{}\nstderr:\n{}".format(
+        result.returncode, result.stdout, result.stderr,
+    )
+    return result, report
 
 
 # Run out-of-process on purpose. The failure this guards against is the
@@ -458,7 +487,12 @@ try:
             time.sleep(0.05)
 
     buf = numpy.zeros((16, 16, 4), "uint8")
-    _linux_x11.screenshot(0, 0, buf)
+    # Every one of these arms a region and reinstalls the handler. If
+    # reinstalling ever recorded the handler as its own predecessor, a
+    # fault would recurse instead of longjmping; 50 rounds makes that
+    # show up as a crash rather than a pass.
+    for _ in range(50):
+        _linux_x11.screenshot(0, 0, buf)
     live = _linux_x11._display_cache_info()
     if not (live["connected"] and live["display"] == display):
         print("SETUP-FAILED: not connected to the private server:", live)
@@ -501,21 +535,191 @@ def test_a_dead_server_raises_instead_of_exiting_the_interpreter():
     protocol errors, and trading a flake for a hard exit would be a bad
     bargain.
     """
-    if not shutil.which("Xvfb"):
-        pytest.skip("Xvfb is not installed; cannot run a disposable X server")
-    number = _free_display_number()
-    if number is None:
-        pytest.skip("no free X display number for a disposable server")
-
-    result = subprocess.run(
-        [sys.executable, "-c", _DEAD_SERVER_SCRIPT, ":%d" % number],
-        capture_output=True, text=True, timeout=120,
-    )
-    report = "exit={}\nstdout:\n{}\nstderr:\n{}".format(
-        result.returncode, result.stdout, result.stderr,
-    )
+    result, report = _run_x_fault_script(_DEAD_SERVER_SCRIPT)
     assert result.returncode == 0, report
     assert "SURVIVED" in result.stdout, report
     # Not merely "did not crash": the connection has to have been given
     # up, so the next call reconnects rather than reusing a dead socket.
+    assert "cannot open X display" in result.stdout, report
+
+
+# --------------------------------------------------------------------
+# Two ways the cache could still hard-exit the interpreter
+#
+# Both are the same failure class the I/O error handler exists to
+# prevent, and both slipped through the first version of it: it armed
+# the guard around the *operation* only, and installed the handler once
+# per *connection*. Each test below fault-injects the specific sequence
+# and asserts the process survives and raises.
+# --------------------------------------------------------------------
+
+
+_SWITCHED_DISPLAY_SCRIPT = r'''
+import os
+import subprocess
+import sys
+import time
+
+from fastgrab import _linux_x11
+
+dead_display, live_display = sys.argv[1], sys.argv[2]
+
+
+def start(display):
+    return subprocess.Popen(
+        ["Xvfb", display, "-screen", "0", "320x240x24", "-ac"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+
+
+def connect(display):
+    os.environ["DISPLAY"] = display
+    deadline = time.time() + 15.0
+    while True:
+        try:
+            return _linux_x11.resolution()
+        except RuntimeError:
+            if time.time() > deadline:
+                print("SETUP-FAILED: %s never became reachable" % display)
+                raise SystemExit(2)
+            time.sleep(0.05)
+
+
+dead = start(dead_display)
+live = start(live_display)
+try:
+    # Touch the survivor first so both servers are known good, then
+    # leave the cache pointing at the one about to be killed.
+    connect(live_display)
+    connect(dead_display)
+    cached = _linux_x11._display_cache_info()
+    if cached["display"] != dead_display or not cached["connected"]:
+        print("SETUP-FAILED: cache holds", cached)
+        raise SystemExit(2)
+
+    dead.terminate()
+    dead.wait(timeout=15)
+    time.sleep(0.2)
+
+    # Now name the healthy display. The cache has to drop the stale
+    # connection to honour that, and dropping it means XCloseDisplay on
+    # a dead socket -- X I/O, and a fatal one if it happens outside an
+    # armed region.
+    os.environ["DISPLAY"] = live_display
+    size = _linux_x11.resolution()
+    after = _linux_x11._display_cache_info()
+    if not after["connected"] or after["display"] != live_display:
+        print("WRONG-DISPLAY:", after)
+        raise SystemExit(3)
+    print("SWITCHED: %r on %s" % (size, after["display"]))
+    print("SURVIVED")
+finally:
+    for proc in (dead, live):
+        if proc.poll() is None:
+            proc.kill()
+'''
+
+
+def test_switching_away_from_a_dead_display_does_not_exit():
+    """Dropping a stale connection is itself X I/O.
+
+    The teardown ran outside the armed region, so a server that had died
+    while idle made XCloseDisplay fault, the handler fell through to its
+    delegation branch, and Xlib's fatal default exited the interpreter --
+    even though the display the caller had just switched *to* was
+    healthy and the call was about to succeed.
+    """
+    result, report = _run_x_fault_script(_SWITCHED_DISPLAY_SCRIPT, displays=2)
+    assert result.returncode == 0, report
+    assert "SURVIVED" in result.stdout, report
+    # Survival is not enough: the switch has to have actually landed on
+    # the healthy display rather than reporting an error from it.
+    assert "SWITCHED:" in result.stdout, report
+
+
+_STOLEN_HANDLER_SCRIPT = r'''
+import ctypes
+import os
+import subprocess
+import sys
+import time
+
+import numpy
+
+from fastgrab import _linux_x11
+
+display = sys.argv[1]
+server = subprocess.Popen(
+    ["Xvfb", display, "-screen", "0", "320x240x24", "-ac"],
+    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+)
+os.environ["DISPLAY"] = display
+try:
+    deadline = time.time() + 15.0
+    while True:
+        try:
+            _linux_x11.resolution()
+            break
+        except RuntimeError:
+            if time.time() > deadline:
+                print("SETUP-FAILED: Xvfb never became reachable")
+                raise SystemExit(2)
+            time.sleep(0.05)
+
+    # Another Xlib user in the process clears the process-global I/O
+    # error handler -- which is what a toolkit does when it tears its
+    # own connection down, and Tk runs in-process under recording/gui.
+    # The extension is now covered by Xlib's fatal default unless it
+    # reinstalls for every protected call rather than once per connect.
+    libX11 = ctypes.CDLL("libX11.so.6")
+    libX11.XSetIOErrorHandler.restype = ctypes.c_void_p
+    libX11.XSetIOErrorHandler.argtypes = [ctypes.c_void_p]
+    stolen_from = libX11.XSetIOErrorHandler(None)
+    if not stolen_from:
+        print("SETUP-FAILED: there was no handler installed to displace")
+        raise SystemExit(2)
+
+    server.terminate()
+    server.wait(timeout=15)
+    time.sleep(0.2)
+
+    buf = numpy.zeros((16, 16, 4), "uint8")
+    try:
+        _linux_x11.screenshot(0, 0, buf)
+    except RuntimeError as exc:
+        dead = _linux_x11._display_cache_info()
+        if dead["connected"]:
+            print("KEPT-DEAD-CONNECTION:", dead)
+            raise SystemExit(3)
+        print("RAISED:", exc)
+        # Surviving is not proof on its own -- reclaim the handler again
+        # and check the extension had put the same function back, rather
+        # than having got lucky some other way.
+        reinstalled = libX11.XSetIOErrorHandler(None)
+        if reinstalled != stolen_from:
+            print("NOT-REINSTALLED: %r vs %r" % (reinstalled, stolen_from))
+            raise SystemExit(3)
+        print("REINSTALLED")
+        print("SURVIVED")
+    else:
+        print("NO-ERROR: captured from a server that is gone")
+        raise SystemExit(3)
+finally:
+    if server.poll() is None:
+        server.kill()
+'''
+
+
+def test_a_stolen_io_error_handler_is_reinstalled():
+    """Xlib's I/O error handler is process-global and anyone can take it.
+
+    Installing it once per connection meant every later cache hit ran
+    under whatever handler was current -- so a disconnect never reached
+    fg_io_error_handler() at all and the setjmp was inert. The
+    reproduction is one XSetIOErrorHandler(NULL) between two calls.
+    """
+    result, report = _run_x_fault_script(_STOLEN_HANDLER_SCRIPT)
+    assert result.returncode == 0, report
+    assert "SURVIVED" in result.stdout, report
+    assert "REINSTALLED" in result.stdout, report
     assert "cannot open X display" in result.stdout, report

--- a/tests/test_x11_lowlevel.py
+++ b/tests/test_x11_lowlevel.py
@@ -723,3 +723,189 @@ def test_a_stolen_io_error_handler_is_reinstalled():
     assert "SURVIVED" in result.stdout, report
     assert "REINSTALLED" in result.stdout, report
     assert "cannot open X display" in result.stdout, report
+
+
+# --------------------------------------------------------------------
+# Two consequences of the connection being persistent rather than
+# per-call: a delegation chain that can close into a loop, and an event
+# queue that nothing reclaims.
+# --------------------------------------------------------------------
+
+
+def test_unread_events_do_not_pile_up_on_the_cached_connection():
+    """MappingNotify reaches every client, and nothing here reads events.
+
+    A per-call connection reclaimed its queue at XCloseDisplay. A cached
+    one does not, so whatever the server pushes accumulates for the life
+    of the process -- worst in exactly the long-running recording loop
+    this cache exists to speed up.
+    """
+    xdisplay = pytest.importorskip("Xlib.display")
+
+    _linux_x11.resolution()
+    before = _linux_x11._display_cache_info()
+
+    other = xdisplay.Display()
+    try:
+        mapping = other.get_pointer_mapping()
+        for _ in range(25):
+            # Every SetPointerMapping makes the server send a
+            # MappingNotify to every client on the display, ours
+            # included, whatever event mask it selected. Setting the
+            # mapping it already has keeps the display untouched.
+            other.set_pointer_mapping(mapping)
+            other.sync()
+            _linux_x11.resolution()
+    finally:
+        other.close()
+
+    # One more call, so anything still sitting in the socket is pulled
+    # into the queue and discarded rather than counted as a leak below.
+    _linux_x11.resolution()
+    after = _linux_x11._display_cache_info()
+
+    # Count arrivals in a way that does not presuppose the fix: an event
+    # that reached this connection was either discarded or is still
+    # sitting in the queue. Asserting only on the discard counter would
+    # make the guard fire first when the drain is removed, and the test
+    # would never get to show the queue growing -- which is the symptom.
+    arrived = (after["events_discarded"] - before["events_discarded"]
+               + after["queued"])
+    assert arrived > 0, (
+        "no MappingNotify reached the cached connection, so this test "
+        "cannot tell a drained queue from one nothing ever arrived on"
+    )
+    assert after["queued"] == 0, (
+        "unread events are accumulating on the cached connection: "
+        "{} still queued after {} arrived".format(after["queued"], arrived)
+    )
+
+
+_HANDLER_CYCLE_SCRIPT = r'''
+import ctypes
+import os
+import subprocess
+import sys
+import time
+
+from fastgrab import _linux_x11
+
+our_display, other_display = sys.argv[1], sys.argv[2]
+
+libX11 = ctypes.CDLL("libX11.so.6")
+HANDLER = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_void_p)
+libX11.XSetIOErrorHandler.restype = HANDLER
+libX11.XSetIOErrorHandler.argtypes = [HANDLER]
+libX11.XOpenDisplay.restype = ctypes.c_void_p
+libX11.XOpenDisplay.argtypes = [ctypes.c_char_p]
+libX11.XSync.restype = ctypes.c_int
+libX11.XSync.argtypes = [ctypes.c_void_p, ctypes.c_int]
+
+
+def say(text):
+    os.write(1, (text + "\n").encode())
+
+
+# The handler that was there first. Reaching it is the whole point: a
+# delegation chain has to end somewhere.
+@HANDLER
+def base_handler(dpy):
+    say("BASE-REACHED")
+    os._exit(0)
+    return 0
+
+
+entries = [0]
+
+
+# What a third party installs: it captures whatever handler is current
+# and passes faults along to it. Harmless in itself -- unless the
+# handler it captured is one that will hand the fault straight back.
+@HANDLER
+def delegating_handler(dpy):
+    entries[0] += 1
+    if entries[0] > 1:
+        say("CYCLE: delegation came back round to this handler")
+        os._exit(9)
+    displaced_by_us(dpy)
+    say("UNREACHABLE: a delegate returned")
+    os._exit(4)
+    return 0
+
+
+def start(display):
+    return subprocess.Popen(
+        ["Xvfb", display, "-screen", "0", "320x240x24", "-ac"],
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+
+
+ours = start(our_display)
+other = start(other_display)
+try:
+    libX11.XSetIOErrorHandler(base_handler)
+
+    os.environ["DISPLAY"] = our_display
+    deadline = time.time() + 15.0
+    while True:
+        try:
+            _linux_x11.resolution()
+            break
+        except RuntimeError:
+            if time.time() > deadline:
+                say("SETUP-FAILED: %s never became reachable" % our_display)
+                raise SystemExit(2)
+            time.sleep(0.05)
+
+    unrelated = libX11.XOpenDisplay(other_display.encode())
+    if not unrelated:
+        say("SETUP-FAILED: could not open %s" % other_display)
+        raise SystemExit(2)
+
+    # A third party installs its delegating handler between two
+    # captures. Whatever it displaces becomes its predecessor.
+    displaced_by_us = libX11.XSetIOErrorHandler(delegating_handler)
+
+    # The second capture. If the extension leaves itself installed
+    # globally, this is where it records the third party's wrapper as
+    # its own predecessor and closes the loop.
+    _linux_x11.resolution()
+
+    other.terminate()
+    other.wait(timeout=15)
+    time.sleep(0.2)
+
+    # A fatal I/O error on a connection that has nothing to do with the
+    # cache. It must reach base_handler.
+    libX11.XSync(unrelated, 0)
+    say("NO-FAULT: the dead connection did not raise an I/O error")
+    raise SystemExit(5)
+finally:
+    for proc in (ours, other):
+        if proc.poll() is None:
+            proc.kill()
+'''
+
+
+def test_the_delegation_chain_cannot_close_into_a_loop():
+    """Staying installed between calls let a chain become a cycle.
+
+    A third party that installs a delegating handler in the gap between
+    two captures captures *this* extension's handler as its predecessor.
+    If the extension then re-installs and records that wrapper as its
+    own predecessor, the two delegate to each other and an I/O error on
+    an unrelated connection never reaches the handler that was there
+    first. Testing "the handler I displaced is not literally me" only
+    ever caught the direct case.
+
+    The subprocess counts how many times the third-party handler is
+    entered, so a cycle terminates the run with a marker instead of
+    recursing without bound; the subprocess timeout is a second
+    backstop.
+    """
+    result, report = _run_x_fault_script(_HANDLER_CYCLE_SCRIPT, displays=2)
+    assert result.returncode == 0, report
+    # Not just "it stopped" -- the fault has to have arrived at the
+    # handler that was installed before any of this started.
+    assert "BASE-REACHED" in result.stdout, report
+    assert "CYCLE" not in result.stdout, report

--- a/tests/test_x11_lowlevel.py
+++ b/tests/test_x11_lowlevel.py
@@ -8,6 +8,9 @@ high-level wrapper) that the X11Backend depends on.
 Skipped on non-Linux: the C extension is not built into wheels for
 Windows or macOS.
 """
+import os
+import shutil
+import subprocess
 import sys
 
 import numpy
@@ -238,3 +241,281 @@ def test_display_context_preserves_the_wrapped_signature():
     assert X11Backend.resolution.__name__ == "resolution"
     assert X11Backend.screenshot.__name__ == "screenshot"
     assert X11Backend.bytes_per_pixel.__name__ == "bytes_per_pixel"
+
+
+# --------------------------------------------------------------------
+# The cached display connection (issue #44)
+#
+# The extension used to run XOpenDisplay(NULL) ... XCloseDisplay() around
+# every single request, so a capture loop opened and tore down one X
+# connection per frame. It now keeps one connection per process, keyed on
+# DISPLAY. These tests pin the four properties that make that safe:
+# connection reuse, honouring a changed DISPLAY, not inheriting the
+# connection across fork(), and turning a server that dies underneath a
+# cached connection into an exception rather than an exit().
+#
+# ``_display_cache_info()`` is private and exists for these tests. There
+# is no honest way to observe "did that open a second connection?"
+# through the public API, and a test that cannot tell reuse from churn
+# would not be testing the fix at all.
+# --------------------------------------------------------------------
+
+
+def test_display_cache_info_reports_the_live_connection():
+    _linux_x11.resolution()
+    info = _linux_x11._display_cache_info()
+    assert info["connected"] is True
+    assert info["display"] == os.environ["DISPLAY"]
+    assert info["pid"] == os.getpid()
+    assert info["opens"] >= 1
+
+
+def test_repeated_captures_reuse_a_single_connection():
+    # The fix itself: 150 server requests over one connection. Before the
+    # cache that was 150 connects and 150 disconnects, which is the churn
+    # #44 blames for the intermittent "cannot open X display".
+    _linux_x11.resolution()
+    before = _linux_x11._display_cache_info()
+    assert before["connected"] is True
+
+    fds_before = len(os.listdir("/proc/self/fd"))
+    buf = numpy.zeros((16, 16, 4), "uint8")
+    for _ in range(50):
+        _linux_x11.screenshot(0, 0, buf)
+        _linux_x11.bytes_per_pixel()
+        _linux_x11.resolution()
+
+    after = _linux_x11._display_cache_info()
+    assert after["opens"] == before["opens"], "a capture loop reconnected"
+    assert after["connected"] is True
+    # A reused connection must also not leak a descriptor per call: the
+    # recovery path drops connections, and dropping one without
+    # reclaiming its descriptor would exhaust the process instead of the
+    # server.
+    assert len(os.listdir("/proc/self/fd")) == fds_before
+
+
+def test_a_changed_display_is_honoured(monkeypatch):
+    # A plain static Display* would keep serving the old connection here,
+    # so the capture would quietly succeed against the display the caller
+    # just stopped naming. Keyed on DISPLAY it reconnects instead — which
+    # is also what keeps
+    # test_unreachable_display_raises_instead_of_segfaulting meaningful.
+    real = os.environ["DISPLAY"]
+    _linux_x11.resolution()
+    first = _linux_x11._display_cache_info()
+    assert first["display"] == real
+
+    monkeypatch.setenv("DISPLAY", ":77")
+    with pytest.raises(RuntimeError, match="cannot open X display"):
+        _linux_x11.resolution()
+    dropped = _linux_x11._display_cache_info()
+    assert dropped["connected"] is False, "kept a connection to the old display"
+    assert dropped["opens"] == first["opens"], "a failed open must not count"
+
+    monkeypatch.setenv("DISPLAY", real)
+    _linux_x11.resolution()
+    back = _linux_x11._display_cache_info()
+    assert back["display"] == real
+    assert back["opens"] == first["opens"] + 1
+
+
+def test_unset_and_empty_display_are_separate_cache_keys(monkeypatch):
+    # XOpenDisplay(NULL) treats the two differently, so the cache has to
+    # as well: neither may be answered from a connection that was opened
+    # while DISPLAY named a real server.
+    real = os.environ["DISPLAY"]
+    _linux_x11.resolution()
+    assert _linux_x11._display_cache_info()["connected"] is True
+
+    monkeypatch.delenv("DISPLAY", raising=False)
+    with pytest.raises(RuntimeError, match="cannot open X display"):
+        _linux_x11.resolution()
+    assert _linux_x11._display_cache_info()["connected"] is False
+
+    monkeypatch.setenv("DISPLAY", real)
+    _linux_x11.resolution()
+    assert _linux_x11._display_cache_info()["connected"] is True
+
+    monkeypatch.setenv("DISPLAY", "")
+    with pytest.raises(RuntimeError, match="cannot open X display"):
+        _linux_x11.resolution()
+    assert _linux_x11._display_cache_info()["connected"] is False
+
+    monkeypatch.setenv("DISPLAY", real)
+    _linux_x11.resolution()
+
+
+def test_close_display_drops_the_cache_and_the_next_call_reconnects():
+    _linux_x11.resolution()
+    before = _linux_x11._display_cache_info()
+
+    _linux_x11._close_display()
+    closed = _linux_x11._display_cache_info()
+    assert closed["connected"] is False
+    assert closed["display"] is None
+
+    _linux_x11.resolution()
+    after = _linux_x11._display_cache_info()
+    assert after["connected"] is True
+    assert after["opens"] == before["opens"] + 1
+
+
+def test_a_forked_child_connects_for_itself():
+    """A child must not speak on the connection it inherited.
+
+    Parent and child hold descriptors onto one socket, and their
+    requests interleave into a single protocol stream — the classic way
+    a multiprocessing pool corrupts an X connection. The child has to
+    notice the pid changed and connect for itself, and it must abandon
+    the inherited Display *without* XCloseDisplay(), which would write to
+    the socket the parent is still using.
+    """
+    _linux_x11.resolution()
+    parent = _linux_x11._display_cache_info()
+    assert parent["connected"] is True
+
+    read_fd, write_fd = os.pipe()
+    pid = os.fork()
+    if pid == 0:
+        # Child. os._exit throughout: running pytest's teardown a second
+        # time, or flushing the parent's captured output, is its own mess.
+        status = 1
+        try:
+            os.close(read_fd)
+            _linux_x11.resolution()
+            info = _linux_x11._display_cache_info()
+            os.write(write_fd, repr(info).encode())
+            if (info["connected"] is True
+                    and info["pid"] == os.getpid()
+                    and info["pid"] != parent["pid"]
+                    and info["opens"] == parent["opens"] + 1):
+                status = 0
+        except BaseException as exc:      # reported through the exit status
+            try:
+                os.write(write_fd, repr(exc).encode())
+            except BaseException:
+                pass
+        finally:
+            os._exit(status)
+
+    os.close(write_fd)
+    reported = os.read(read_fd, 8192).decode()
+    os.close(read_fd)
+    _, wait_status = os.waitpid(pid, 0)
+    assert os.WIFEXITED(wait_status), "the child died on a signal: " + reported
+    assert os.WEXITSTATUS(wait_status) == 0, "child reported: " + reported
+
+    # And the parent's own connection came through untouched — neither
+    # closed by the child nor left with a corrupted request stream.
+    after = _linux_x11._display_cache_info()
+    assert after["opens"] == parent["opens"]
+    assert after["pid"] == parent["pid"]
+    _linux_x11.resolution()
+
+
+def _free_display_number():
+    for number in range(90, 110):
+        if os.path.exists("/tmp/.X11-unix/X%d" % number):
+            continue
+        if os.path.exists("/tmp/.X%d-lock" % number):
+            continue
+        return number
+    return None
+
+
+# Run out-of-process on purpose. The failure this guards against is the
+# interpreter *exiting*, which an in-process test cannot report — it
+# would take the whole pytest session down with it. Out here a
+# regression shows up as a non-zero exit status plus Xlib's "XIO: fatal
+# IO error" on stderr, both of which the assertion prints.
+_DEAD_SERVER_SCRIPT = r'''
+import os
+import subprocess
+import sys
+import time
+
+import numpy
+
+from fastgrab import _linux_x11
+
+display = sys.argv[1]
+server = subprocess.Popen(
+    ["Xvfb", display, "-screen", "0", "320x240x24", "-ac"],
+    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+)
+os.environ["DISPLAY"] = display
+try:
+    deadline = time.time() + 15.0
+    while True:
+        try:
+            _linux_x11.resolution()
+            break
+        except RuntimeError:
+            if time.time() > deadline:
+                print("SETUP-FAILED: Xvfb never became reachable")
+                raise SystemExit(2)
+            time.sleep(0.05)
+
+    buf = numpy.zeros((16, 16, 4), "uint8")
+    _linux_x11.screenshot(0, 0, buf)
+    live = _linux_x11._display_cache_info()
+    if not (live["connected"] and live["display"] == display):
+        print("SETUP-FAILED: not connected to the private server:", live)
+        raise SystemExit(2)
+
+    server.terminate()
+    server.wait(timeout=15)
+    time.sleep(0.2)
+
+    # The cached connection is now a dead socket. Xlib's default I/O
+    # error handler would print and call exit() right here.
+    try:
+        _linux_x11.screenshot(0, 0, buf)
+    except RuntimeError as exc:
+        dead = _linux_x11._display_cache_info()
+        if dead["connected"]:
+            print("KEPT-DEAD-CONNECTION:", dead)
+            raise SystemExit(3)
+        print("RAISED:", exc)
+        print("SURVIVED")
+    else:
+        print("NO-ERROR: captured from a server that is gone")
+        raise SystemExit(3)
+finally:
+    if server.poll() is None:
+        server.kill()
+'''
+
+
+def test_a_dead_server_raises_instead_of_exiting_the_interpreter():
+    """The hazard the cache introduces, and the reason it is survivable.
+
+    Opening a connection per call meant a server that had gone away was
+    met by XOpenDisplay returning NULL — a clean RuntimeError. A cached
+    connection meets it as an Xlib I/O error instead, and Xlib's default
+    I/O error handler prints a diagnostic and calls exit(): no
+    exception, no traceback, the interpreter simply stops. That is the
+    same class of failure
+    test_low_level_screenshot_rejects_negative_origin describes for
+    protocol errors, and trading a flake for a hard exit would be a bad
+    bargain.
+    """
+    if not shutil.which("Xvfb"):
+        pytest.skip("Xvfb is not installed; cannot run a disposable X server")
+    number = _free_display_number()
+    if number is None:
+        pytest.skip("no free X display number for a disposable server")
+
+    result = subprocess.run(
+        [sys.executable, "-c", _DEAD_SERVER_SCRIPT, ":%d" % number],
+        capture_output=True, text=True, timeout=120,
+    )
+    report = "exit={}\nstdout:\n{}\nstderr:\n{}".format(
+        result.returncode, result.stdout, result.stderr,
+    )
+    assert result.returncode == 0, report
+    assert "SURVIVED" in result.stdout, report
+    # Not merely "did not crash": the connection has to have been given
+    # up, so the next call reconnects rather than reusing a dead socket.
+    assert "cannot open X display" in result.stdout, report


### PR DESCRIPTION
Fixes #44.

`screenshot.c` opened **and closed** an X connection on every call, at all three
entry points. This caches one `Display*` per process.

## The flake mechanism, reproduced

#44 was filed without a reproduction — it had been seen once in CI, an unchanged
re-run passed, and 25 consecutive local suite runs never showed it. It reproduced
while measuring this branch, on the **pre-fix** build, in a loop that does nothing
but the churn the issue blames:

```python
for _ in range(2000):
    _linux_x11.resolution()      # each call: XOpenDisplay ... XCloseDisplay
```

```
RuntimeError: cannot open X display: is DISPLAY set and the X server reachable?
```

Same 6000 calls on this branch: no failure, at ~10.7 µs/call. The host was heavily
loaded at the time, which matches the CI theory — a busy 2-core runner plus
connection churn, rather than anything wrong with the display.

That is the mechanism demonstrated, not merely argued. It is still not proof that
the single observed CI failure was this and nothing else; only the CI record over
time can say that.

## Design

All three entry points go through `fg_call_with_display(op, ctx)`.

**DISPLAY key.** `getenv("DISPLAY")` is read every call and compared with a copy
taken at connect time; unset and empty are distinct keys. `XOpenDisplay(NULL)` still
does the name resolution, so Xlib's handling of transport prefixes, socket pathnames
and IPv6 literals is untouched. A mismatch closes and reconnects — which is what
keeps `test_unreachable_display_raises_instead_of_segfaulting` meaningful.

**Threads.** The existing code never released the GIL and still doesn't. Holding it
across the round trip is what makes a shared `Display*` safe: two Python threads
cannot be inside libX11 on this connection at once. `XInitThreads()` is deliberately
not called — it must run before any other Xlib call process-wide, so a library
cannot honestly promise it, and it changes locking for every other Xlib user in the
process.

**fork().** The owning pid is recorded and checked each call. A child abandons the
inherited `Display` *without* `XCloseDisplay` — that would write to the socket the
parent is still using — closes only its own descriptor, and reconnects. The struct
leaks once per fork, never per call.

**Shutdown.** No `atexit`, no finalizer, consistent with the wlr and windows backends
and with `_run_pytest_clean_exit.py`. The kernel closes the socket.

**Error recovery — the real hazard.** With a cached connection, a server that dies
between captures meets Xlib's default I/O error handler, which calls `exit()`. A
chaining `XIOErrorHandler` now `longjmp`s out, drops the connection and retries once
on a fresh one, so a restarted server behaves as it did when every call reconnected.
Only a *reused* connection is retried, so a genuinely dead server cannot loop. The
handler only jumps for its own display while armed and otherwise delegates to any
previously installed handler — relevant because `recording/gui` runs Tk, which holds
its own X connection.

## One change that was not asked for

The bounds check now uses `XGetGeometry` on the root instead of
`ScreenOfDisplay()->width/height`. Those come from the connection setup and are only
refreshed by a client that processes RandR events, which this one does not. With a
per-call connection, reading them was accurate by accident; with a cache they would
freeze, and a screen that later *shrank* would pass the check and reach `XGetImage`
as a BadMatch — delivered to Xlib's default error handler, i.e. an interpreter exit.
The extra round trip is priced into the numbers below.

## Performance — measured, and narrower than it first looked

An initial before/after pair suggested 13-33% at 1080p/4K. **That was machine drift**:
an interleaved re-run put pre-fix 4K at 32.8/34.8 fps, the same as post-fix. Only
360p separates cleanly (~+41%); at 720p and above the `XGetImage` transfer dominates
and the difference is inside host noise.

What actually changed is per-call overhead (alternating A/B, 3 rounds, min of 5
batches of 2000):

| | before | after |
|---|---|---|
| `resolution()` | 90.6 / 88.6 / 86.8 µs | 10.3 / 10.2 / 10.4 µs |
| `bytes_per_pixel()` | 101.0 / 102.4 / 97.8 µs | 11.0 / 10.8 / 10.7 µs |
| `screenshot` 240x180 | 128.6 / 128.0 / 125.8 µs | 45.0 / 47.2 / 44.9 µs |

~85 µs of connection setup gone per call. **A per-call overhead win, not a
throughput win at 1080p** — say so rather than quoting an fps number.

## Tests

`docker compose run --rm test` -> **258 passed** (was 251).
`docker compose run --rm test-wayland` -> **23 passed**.
Full suite 10x back to back: 0 failures.

Seven new tests: connection reuse (150 requests, one connection, plus an fd count),
DISPLAY rekeying, unset vs empty as distinct keys, explicit close/reconnect, fork
isolation (child connects for itself; the parent's connection verifiably survives),
and dead-server survival. Observability is a private `_display_cache_info()` /
`_close_display()` — there is no honest way to tell reuse from churn through the
public API.

The dead-server test is not vacuous: with the handler install disabled it fails with
exit 1 and `X connection to :90 broken (explicit kill or server shutdown)` on stderr,
which is precisely the hard exit it guards against.

## Known nit

`-Wextra` reports a `-Wclobbered` false positive on the inlined acquire helper: gcc
flags a value live across the `setjmp`, not one read after it. The project's own
flags (`-Wall -Wsign-compare`) are clean, and there is a comment in the code saying
so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLmJd7aNG8CRS7EQ9waLqD


---

## Review round: two interpreter-exit paths, found and fixed

An independent review (`codex review`) found **two ways this change could still hard-exit
Python** — the exact failure class the `XIOErrorHandler` work exists to prevent. Both were
reproduced by fault injection, and both are now fixed with out-of-process regression tests.

**[P1] Teardown during a `DISPLAY` switch ran unguarded.** If the cached server died and the
caller then changed `DISPLAY`, `XCloseDisplay()` ran on the dead connection *before* the guard
was armed. That call does real I/O (KillClient + sync), so the handler fired unarmed, delegated
to the previous fatal handler, and exited Python — **even though the newly selected display was
healthy**. `_close_display()` had the same hole. Closes now go through
`fg_close_display_guarded()`, which has its own `setjmp` region; the recovery path reads the
file static rather than a local, which would be indeterminate after a `longjmp`.

**[P2] The handler was installed only on connect.** If any other Xlib user in the process
installed or restored an I/O handler afterwards, every cache hit took the early return and never
reinstalled ours, so the `setjmp` was inert. This is exactly the Tk-in-`recording/gui` case
flagged in the design notes above. `fg_io_arm()` now reinstalls per protected region; the
`prev != fg_io_error_handler` check keeps it from becoming its own predecessor and preserves a
third party's handler as the delegate. Re-measured overhead: unchanged (a pointer swap).

Both tests run **out of process** and assert exit status plus a positive marker, because the
failure being guarded against is the interpreter *exiting* — an in-process assertion cannot tell
exit-1 from a raised exception. Neither passes by mere survival: P1 asserts the switch actually
lands on the healthy display, and P2 asserts the stolen handler pointer is reclaimed intact.

Verified against the previous commit: both fail there (`exit=1`, with
`X connection to :90 broken` and `XIO: fatal IO error`) and pass here.

`docker compose run --rm test` -> **282 passed**; `test-wayland` -> **23 passed**.

### Still not covered

* `XOpenDisplay` remains unarmed — it has no `Display*` to match on yet, and a wildcard would
  swallow another thread's fault. libX11 returns NULL rather than calling `_XIOError` on setup
  failure, so this is unchanged from before the cache, but it is not *proven* the way the rest now is.
* No end-to-end test that a live third-party handler still receives faults for its own display.
  The reclaim path is tested; the delegation path is reasoned, not exercised.
* The handler is never uninstalled. If the extension module were unloaded, Xlib would hold a
  dangling pointer — CPython effectively never unloads extension modules.


## Second review round: a handler cycle and an unbounded queue

Both are consequences of the connection being persistent, and neither is a repeat of the first round.

**Indirect delegation cycle.** The `prev != fg_io_error_handler` check prevented direct
self-reference but not this: because the handler stayed *globally installed between*
captures, a third party installing a delegating handler in the gap ended up with ours as
its predecessor, and the next capture took theirs as `fg_io_prev` — a two-handler loop
that an I/O error on an unrelated connection would bounce around forever. The fix is to
stop being globally installed: `fg_io_arm()` saves the handler it displaces and
`fg_io_disarm()` restores it, so ours exists only inside a protected region and nothing
can chain to it. The GIL is held throughout, so no other Xlib user in the process can
install while we are swapped in.

Residual, recorded rather than papered over: a *non-Python* thread calling
`XSetIOErrorHandler` inside that window would have its install overwritten on disarm.
That is strictly narrower than the cycle it replaces, and Xlib's single global handler
offers nothing better.

**The event queue was never drained.** `MappingNotify` reaches every client regardless of
event mask, so any other client changing a keyboard or pointer mapping queues an event
here. Per-call connections reclaimed the queue at `XCloseDisplay`; a cached one grew
without bound — in exactly the long-running `fastgrab.recording` loop this change exists
to speed up. `fg_drain_events()` now runs at the end of every protected call, inside the
armed region. `QueuedAlready` is a queue-length read and never a socket read, so it cannot
block or fault.

### Verification

Both controls were run against the previous commit rather than asserted:

* **Cycle:** previous commit exits 9 with `CYCLE: delegation came back round to this
  handler`; fixed, exit 0 with `BASE-REACHED`. The test asserts the fault *reaches the base
  handler*, not merely that the process stopped, and the third-party handler counts its own
  entries so a cycle fails in milliseconds instead of hanging.
* **Queue:** with the drain neutered but the counters intact, `assert 25 == 0` — 25 events
  still queued after 25 arrived. The assertion counts arrivals as discarded + still-queued,
  so it does not presuppose the fix. (An earlier version of this test was rejected by its own
  control: it failed on a guard assertion before it could show growth.)

Overhead re-measured, since the drain adds work to every call: 10.1/10.3/41.9 and
10.2/10.4/42.6 µs vs 10.2-10.4/10.6-11.0/44.9-47.2 µs before. No measurable cost; the
numbers quoted above still stand.

`docker compose run --rm test` -> **284 passed**; `test-wayland` -> **23 passed**.


## Third review round: the tests were leaking X servers

The C code came back clean this round; all three findings were in the new fault tests, and
this commit is test-only (`screenshot.c` is byte-identical to the previous commit).

The server lifecycle now lives in one shared prelude used by every fault script: bounded
readiness waits for *every* server before anything connects (a race meant a slow second
Xvfb could fail setup with a perfectly correct extension), `terminate()` + `wait()` with
`kill()` only as a bounded fallback so Xvfb can unlink its socket and lock file, and a
single `finish()` exit path that cleans up before `os._exit` — necessary because an I/O
error handler cannot return, so that is the only place cleanup can happen on that path.
The harness also now waits for the display numbers it handed out to come back and **fails
if they don't**, carrying the run's exit status, stdout and stderr so it can never mask a
real failure.

Why this mattered more than its severity suggests — 25 iterations of the five fault tests
in one container, before the fix:

```
before: free display numbers in 90..129: 40, Xvfb processes: 0
iterations 1-19:  .....       (green)
iterations 20-25: .s..s       (two tests SKIPPED, still "green")
after:  free display numbers in 90..129: 1, Xvfb processes: 19
        38 stale sockets, 38 stale lock files
```

Nineteen honest runs, then a suite that looks identical in CI while a third of the fault
coverage has silently stopped running — a green build asserting less and less. After the
fix, 25 iterations end with all 40 display numbers free and zero surviving processes.
Independently re-checked over 12 iterations: no Xvfb, no sockets, no locks, nothing left
in the 90-129 range.

All four fault-injection controls re-verified and still failing with their fixes neutered.
`docker compose run --rm test` -> **284 passed**; `test-wayland` -> **23 passed**.
