### PR TITLE
release: bump version to 0.4.0

### DIFF
--- a/fastgrab/metadata.py
+++ b/fastgrab/metadata.py
@@ -12,7 +12,7 @@ try:
     from importlib.metadata import version as _dist_version
     version = _dist_version(package)
 except Exception:  # PackageNotFoundError when not installed
-    version = '0.3.0'
+    version = '0.4.0'
 description = 'Low level screen capture package with a numpy interface'
 authors = ['Mher Kazandjian']
 authors_string = ', '.join(authors)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastgrab"
-version = "0.3.0"
+version = "0.4.0"
 description = "Low level screen capture package with a numpy interface"
 authors = ["Mher Kazandjian <mherkazandjian@gmail.com>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
Version bump only — **this does not publish anything**. Publishing happens when a GitHub
Release is created, which triggers the trusted-publishing workflow.

## What 0.4.0 contains

| PR | issue | change |
|---|---|---|
| #42 | #39 | Windows capture is DPI-aware; coordinates are physical device pixels at any display scale |
| #43 | #38 | wlr sub-region capture converts device pixels to logical coordinates, so scaled outputs work |
| #45 | #44 | X display failures report the DISPLAY state and whether a retry succeeds |
| #47 | #46 | macOS redraws the capture when CoreGraphics returns an oversized provider — this was a hard crash on Apple Silicon |
| #48 | #44 | the X display connection is cached instead of reopened per call |

## Why minor and not patch

Two of these change behaviour rather than only fixing it:

* **Windows** previously reported and captured in whatever DPI context the host process
  happened to have. At a display scale other than 100% it now returns *different, correct*
  coordinates — existing callers computing bboxes against the old values are affected.
* **wlr** sub-region capture on a scaled output previously refused; it now works.

`#47` is the one users are most likely to be waiting for: on affected Apple Silicon setups
`Screenshot().capture()` raises and there is no workaround in 0.3.0.

## Release checklist

1. Merge this PR.
2. Tag `0.4.0` on `main` — the workflow requires the tag to match `pyproject.toml`, and PyPI
   never allows a filename to be reused.
3. Create a **published** GitHub Release for that tag. A push alone cannot ship a version;
   `workflow_dispatch` targets TestPyPI for rehearsals.
4. The workflow builds an **sdist only**, deliberately: a wheel built on a runner carries that
   runner's glibc in an unaudited manylinux tag, and poetry-core emits `py3-none-any` on
   non-Linux hosts, which pip would prefer over the sdist on Linux and hand those users a
   package with no C extension.

## Caveat worth carrying into the release notes

The macOS fix in #47 is verified by mocked CoreGraphics tests on Linux, not on real hardware —
the `macos` CI job is a 1x display with an exactly-sized provider, so it exercises only the
unchanged fast path. #46 is deliberately left open pending confirmation from an Apple Silicon
user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLmJd7aNG8CRS7EQ9waLqD
