### PR TITLE
tests: stop the recorder smoke test on a frame count, not a clock

### DIFF
--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -9,6 +9,7 @@ import argparse
 import os
 import shutil
 import subprocess
+import threading
 import time
 
 import numpy
@@ -425,8 +426,6 @@ def test_recorder_rejects_region_too_small_after_alignment(tmp_path):
 
 @pytest.mark.skipif(not _x11_available(), reason="needs X11 DISPLAY")
 def test_recorder_countdown_cancelled_records_nothing(tmp_path):
-    import threading
-
     out = tmp_path / "never.mp4"
     rec = Recorder(
         output_path=str(out), bbox=(0, 0, 120, 90), fps=10, backend="x11",
@@ -450,9 +449,28 @@ def test_recorder_smoke_mp4(tmp_path):
         fps=10,
         backend="x11",
     )
+    # Stop on a frame count, not on a clock. This used to record for a
+    # fixed 0.6 s and assert >= 4 frames, which at fps=10 demands the host
+    # sustain ~7 fps of capture-plus-encode — a statement about how fast
+    # the machine is rather than about the recorder, and one a loaded CI
+    # runner does not honour (issue #50; seen failing with `assert 1 >= 4`).
+    # record() checks stop_event at the top of every iteration and calls
+    # on_progress after each captured frame, so asking for the frames we
+    # want is exact. `duration` stays only as a generous backstop, so a
+    # genuinely broken capture loop fails the suite instead of hanging it.
+    wanted = 4
+    stop = threading.Event()
     seen = []
-    stats = rec.record(duration=0.6, on_progress=lambda n, _e: seen.append(n))
-    assert stats["frames"] >= 4
+
+    def progress(n, _elapsed):
+        seen.append(n)
+        if n >= wanted:
+            stop.set()
+
+    stats = rec.record(duration=30.0, stop_event=stop, on_progress=progress)
+    # A slow host now takes longer rather than failing; only a host that
+    # cannot manage 4 frames in 30 s trips this, which is a real problem.
+    assert stats["frames"] >= wanted
     # ffmpeg receives at least one frame per captured frame; any extras
     # are duplicates written to hold the target rate.
     assert stats["written_frames"] >= stats["frames"]


### PR DESCRIPTION
Fixes #50.

`test_recorder_smoke_mp4` recorded for a fixed 0.6 s at `fps=10` and asserted
`frames >= 4` — which requires the host to sustain roughly 7 fps of
capture-plus-encode. That is a statement about how fast the machine is, not about
what the recorder does, and a loaded runner does not honour it. Observed failing
2 of 10 full-suite runs on a busy workstation with `assert 2 >= 4` and
`assert 1 >= 4`.

This is distinct from #44, which was the same test failing with
`cannot open X display` — a different mechanism, fixed by #48.

## The change

`record()` already checks `stop_event` at the top of every iteration and calls
`on_progress` after each captured frame, so the test can ask for exactly the
frames it wants:

```python
wanted = 4
stop = threading.Event()

def progress(n, _elapsed):
    seen.append(n)
    if n >= wanted:
        stop.set()

stats = rec.record(duration=30.0, stop_event=stop, on_progress=progress)
assert stats["frames"] >= wanted
```

`duration` stays only as a generous backstop, so a genuinely broken capture loop
fails the suite instead of hanging it. A slow host now takes *longer* rather than
failing.

## Demonstrated, not assumed

Under 4x CPU load, on the same box at the same moment, both forms measured
side by side:

```
trial 0: old(0.6s)=6 frames -> PASS | new(count)=4 frames in 0.4s -> PASS
trial 1: old(0.6s)=6 frames -> PASS | new(count)=4 frames in 0.5s -> PASS
trial 2: old(0.6s)=6 frames -> PASS | new(count)=4 frames in 0.5s -> PASS
trial 3: old(0.6s)=6 frames -> PASS | new(count)=4 frames in 0.4s -> PASS
trial 4: old(0.6s)=3 frames -> FAIL | new(count)=4 frames in 0.4s -> PASS
```

Trial 4 is the bug: the fixed window came up short while the frame-count form got
what it needed.

**Worth being precise about the evidence**: the flake is stochastic — 1 in 5 trials
at that load. A straight comparison of 8 runs each passed 8/8 for *both* forms and
separated nothing, which is why the measurement above compares frames captured
rather than pass/fail counts. This makes the failure impossible by construction
rather than merely less likely.

## Side effects

* Slightly **faster**: 0.45 s vs 0.6 s, since it stops as soon as it has 4 frames.
* Removes a latent `IndexError`: `seen[-1]` was evaluated after the frame
  assertion, so a zero-frame run reported `IndexError` rather than the count.
* `threading` moves to a module-level import; a sibling test was importing it
  locally.

`docker compose run --rm test` -> **284 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLmJd7aNG8CRS7EQ9waLqD
