### PR TITLE
ci: make the wayland, windows and macos jobs blocking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,6 @@ jobs:
   wayland:
     name: linux wayland (wlr-screencopy via cage)
     runs-on: ubuntu-latest
-    # Headless wlroots can be flaky in CI — fail-soft initially. Drop this
-    # once the job's pass-rate is steady.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -29,9 +26,6 @@ jobs:
   windows:
     name: windows (BitBlt + DIBSection)
     runs-on: windows-latest
-    # New backend — fail-soft until the runner's display behaviour proves
-    # stable. Promote to required after a clean baseline.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -50,9 +44,6 @@ jobs:
   macos:
     name: macos (CGDisplayCreateImage)
     runs-on: macos-latest
-    # Same fail-soft rationale as windows; macOS Screen Recording (TCC)
-    # behaviour on the runner has not yet been observed end-to-end.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/agents/fastgrab-dev.md
+++ b/agents/fastgrab-dev.md
@@ -54,7 +54,7 @@ Makefile                    host targets; `make <target> docker=1` routes throug
 docker-compose.yml          services: dev (VNC desktop), test, test-wayland, benchmark
 docker/Dockerfile           python:3.11-slim + gcc/libx11-dev/xvfb/cage/ffmpeg/poetry/pytest/...
 docker/*.sh                 entrypoint (in-place ext build), start-desktop, start-wayland-desktop
-.github/workflows/test.yml  CI: x11 (required), wayland / windows / macos (fail-soft)
+.github/workflows/test.yml  CI: x11 / wayland / windows / macos (all blocking)
 fastgrab/
   __init__.py               version/author metadata only — keep it import-cheap
   metadata.py
@@ -209,10 +209,10 @@ Test-writing rules:
 Four jobs on every push and PR:
 
 - `x11` — ubuntu-latest, **required**: `docker compose run --rm test`
-- `wayland` — ubuntu-latest, `continue-on-error` (headless wlroots flaky)
-- `windows` — windows-latest, `continue-on-error`: `pip install .` then
+- `wayland` — ubuntu-latest, blocking
+- `windows` — windows-latest, blocking: `pip install .` then
   `pytest -m "not wayland and not integration"`
-- `macos` — macos-latest, `continue-on-error`: same as windows
+- `macos` — macos-latest, blocking: same as windows
 
 Fail-soft jobs graduate to required once their pass rate is steady. There
 are no release/publish steps in CI.


### PR DESCRIPTION
The `wayland`, `windows` and `macos` jobs were `continue-on-error: true`, so only
`x11` could fail a run. Their own comments said to drop that "once the pass-rate is
steady" and "after a clean baseline".

## The baseline

Per-job conclusions across the last 30 runs of `test.yml`:

```
30  linux x11 (xvfb + libX11)            success
30  linux wayland (wlr-screencopy…)      success
30  windows (BitBlt + DIBSection)        success
30  macos (CGDisplayCreateImage)         success
```

**One caveat, stated rather than buried:** the single `x11` failure in that window
(run 34009079176 — the #44 flake) was replaced when I re-ran the job, so that 30/30
is flattered by exactly one re-run. Both causes of that flake are now fixed (#48 for
the display churn, #51 for the wall-clock frame assertion).

## Why now rather than on the streak alone

This week landed real changes in all three fail-soft backends:

| PR | backend |
|---|---|
| #42 | Windows — DPI-aware capture |
| #43 | wlr — logical sub-region coordinates |
| #47 | macOS — oversized-provider redraw |

They now carry recently-changed code whose CI could go red without anyone being made
to notice. That is backwards. The `macos` job is particularly load-bearing: #47 is
verified by mocked CoreGraphics tests running on Linux and **has never executed on a
Mac**, so that job is the only automated evidence it works at all.

## What this does not do

`main` has **no branch protection**, so a red job is now visible and fails the run,
but nothing mechanically prevents a merge. Making these *required* in the enforcing
sense is a repo setting rather than a workflow change — worth doing separately, and
it needs a decision about whether direct pushes to `main` should still be allowed.

Docs updated (`agents/fastgrab-dev.md`) to stop describing the fail-soft arrangement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLmJd7aNG8CRS7EQ9waLqD
