### PR TITLE
recording: describe frames to ffmpeg as bgr0, not bgra

### DIFF
--- a/fastgrab/recording/encoder.py
+++ b/fastgrab/recording/encoder.py
@@ -163,7 +163,14 @@ def _ffmpeg_args(codec: str, width: int, height: int, fps: int, output: str,
         "-loglevel", "error",
         "-f", "rawvideo",
         "-vcodec", "rawvideo",
-        "-pix_fmt", "bgra",
+        # bgr0, not bgra: the fourth byte of a fastgrab frame is unused
+        # padding, not transparency (X11's XGetImage leaves it zero on a
+        # 24-bit visual). Describing it as bgra told ffmpeg every pixel
+        # was fully transparent, which mp4/webm ignore -- they force
+        # yuv420p -- but GIF does not: paletteuse treats alpha below its
+        # default threshold of 128 as transparent, so every recorded GIF
+        # came out completely invisible.
+        "-pix_fmt", "bgr0",
         "-s", "{}x{}".format(width, height),
         "-r", str(fps),
         "-i", "-",

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -441,6 +441,48 @@ def test_recorder_countdown_cancelled_records_nothing(tmp_path):
 
 @requires_ffmpeg
 @pytest.mark.skipif(not _x11_available(), reason="needs X11 DISPLAY")
+def test_recorded_gif_is_not_transparent(tmp_path):
+    """Every recorded GIF used to come out completely invisible.
+
+    A captured frame's fourth byte is unused padding, not transparency —
+    X11's XGetImage leaves it zero on a 24-bit visual. The encoder
+    described its rawvideo input to ffmpeg as ``bgra``, so ffmpeg read
+    that padding as "fully transparent". mp4 and webm never noticed
+    because they force yuv420p and drop alpha, but GIF keeps it:
+    ``paletteuse`` treats alpha below its default threshold of 128 as
+    transparent, so 100% of the pixels in the output were.
+
+    Asserted on the decoded image rather than on ffmpeg's argv, so it
+    stays true whatever the filter chain becomes.
+    """
+    out = tmp_path / "clip.gif"
+    rec = Recorder(
+        output_path=str(out), bbox=(0, 0, 320, 240), fps=10, backend="x11",
+    )
+    stop = threading.Event()
+
+    def progress(n, _elapsed):
+        if n >= 3:
+            stop.set()
+
+    rec.record(duration=30.0, stop_event=stop, on_progress=progress)
+    assert out.exists() and out.stat().st_size > 0
+
+    raw = subprocess.run(
+        ["ffmpeg", "-v", "error", "-i", str(out),
+         "-f", "rawvideo", "-pix_fmt", "rgba", "-"],
+        capture_output=True, check=True,
+    ).stdout
+    alpha = numpy.frombuffer(raw, dtype=numpy.uint8).reshape(-1, 4)[:, 3]
+    assert alpha.size > 0, "decoded no pixels from the gif"
+    assert alpha.min() == 255, (
+        "{:.1f}% of the gif's pixels are transparent".format(
+            (alpha == 0).mean() * 100)
+    )
+
+
+@requires_ffmpeg
+@pytest.mark.skipif(not _x11_available(), reason="needs X11 DISPLAY")
 def test_recorder_smoke_mp4(tmp_path):
     out = tmp_path / "smoke.mp4"
     rec = Recorder(


### PR DESCRIPTION
**Every recorded GIF came out completely invisible.**

```
fastgrab-record --fullscreen --duration 1 -o out.gif
```

produced a file whose every pixel was fully transparent.

## Cause

A fastgrab frame's fourth byte is unused **padding, not transparency** — X11's
`XGetImage` leaves it zero on a 24-bit visual, which `Screenshot.capture()` already
documents. Measured on a live capture:

```
alpha channel: min=0 max=0 unique=[0]
```

The encoder described its rawvideo input to ffmpeg as `bgra`, so ffmpeg read that
padding as "fully transparent".

mp4 and webm never noticed, because both force `-pix_fmt yuv420p` and drop alpha
entirely. **GIF keeps it**: `paletteuse` treats alpha below its default threshold of
128 as transparent, so every pixel qualified.

## Fix

One argument: `bgr0` instead of `bgra`. That is simply the honest description of
B, G, R, padding — so nothing needs masking or converting, and the other codecs are
unaffected because they already discarded the byte.

## Measured, before and after

A 3-frame 320x240 recording, decoded back to RGBA:

| | file size | alpha min/max | transparent |
|---|---|---|---|
| before | 882 bytes | 0 / 0 | **100.0%** |
| after | 1340 bytes | 255 / 255 | 0.0% |

The size difference is the point: 882 bytes was a GIF containing essentially nothing.

## Test

`test_recorded_gif_is_not_transparent` records a short clip, decodes it back through
ffmpeg and asserts every pixel is opaque. It asserts on the **decoded image** rather
than on ffmpeg's argv, so it stays meaningful whatever the filter chain becomes.

Verified to fail on the old code — `alpha.min() == 0` across 230,400 pixels — and the
mp4 smoke test passes unchanged in the same run.

`docker compose run --rm test` -> **285 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLmJd7aNG8CRS7EQ9waLqD
