### PR TITLE
windows: validate the destination before the raw memmove

### DIFF
--- a/fastgrab/backends/windows.py
+++ b/fastgrab/backends/windows.py
@@ -35,6 +35,8 @@ import contextlib
 import ctypes
 from ctypes import wintypes  # only available on Windows; gated by importer
 
+import numpy
+
 from .base import BaseBackend
 
 
@@ -158,6 +160,39 @@ def _thread_dpi_aware(user32):
             set_dpi_ctx(previous)
 
 
+def _validate_destination(img):
+    """Reject a destination this backend cannot safely fill.
+
+    ``screenshot()`` copies with :func:`ctypes.memmove`, which walks
+    ``height * width * 4`` bytes forward from the array's data pointer
+    and knows nothing about strides. A non-contiguous view satisfies the
+    documented shape and dtype while pointing somewhere else entirely --
+    ``arr[::-1]`` starts at the *last* row -- so the copy would run past
+    the end of the allocation and corrupt the heap.
+
+    This backend is alone in needing the guard: macOS and wlr assign
+    through numpy (``img[:] = ...``), which is stride-aware and refuses a
+    read-only destination by itself. The checks and their wording mirror
+    the X11 C extension's, so the directly-callable backend API rejects
+    the same things on every platform. Rejected rather than coerced: a
+    coerced copy would be filled and then dropped on the floor.
+    """
+    if not isinstance(img, numpy.ndarray):
+        raise TypeError("image buffer must be a numpy ndarray")
+    if img.ndim != 3 or img.shape[2] != 4:
+        raise ValueError("image buffer must be a (height, width, 4) array")
+    if img.dtype != numpy.uint8:
+        raise ValueError("image buffer must have dtype uint8")
+    flags = img.flags
+    if not (flags["C_CONTIGUOUS"] and flags["ALIGNED"] and flags["WRITEABLE"]):
+        raise ValueError(
+            "image buffer must be C-contiguous, aligned and writable"
+        )
+    height, width = img.shape[:2]
+    if height <= 0 or width <= 0:
+        raise ValueError("image buffer height and width must be positive")
+
+
 class WindowsBackend(BaseBackend):
     def __init__(self):
         self._user32, self._gdi32 = _load_libs()
@@ -207,6 +242,9 @@ class WindowsBackend(BaseBackend):
         return 4
 
     def screenshot(self, x, y, img):
+        # Before anything touches the screen: the copy at the end is a
+        # raw memmove and cannot recover from a bad destination.
+        _validate_destination(img)
         h, w, _ = img.shape
         self._ensure_bitmap(w, h)
 

--- a/tests/test_windows_backend.py
+++ b/tests/test_windows_backend.py
@@ -512,3 +512,85 @@ def test_a_stale_screen_dc_would_serve_the_virtualized_desktop():
     got = numpy.frombuffer(buf, numpy.uint8).reshape(6, 8, 4)
     assert numpy.array_equal(got, user32.virtual_screen[0:6, 0:8])
     assert not numpy.array_equal(got, user32.screen[0:6, 0:8])
+
+
+# -------- destination validation --------
+#
+# screenshot() finishes with a raw ctypes.memmove, which walks
+# height*width*4 bytes forward from the array's data pointer and knows
+# nothing about strides. Everything below would previously have reached
+# that memmove. The reversed-view case is the dangerous one: it satisfies
+# the documented shape and dtype while its data pointer sits at the *last*
+# row, so the copy ran off the end of the allocation.
+
+
+def _reject(backend, gdi32, img, exc, match):
+    with pytest.raises(exc, match=match):
+        backend.screenshot(0, 0, img)
+    # Refused before anything touched the screen.
+    assert gdi32.blits == []
+
+
+def test_reversed_view_is_rejected_not_overrun(make_backend):
+    backend, _user32, gdi32 = make_backend()
+    buf = numpy.zeros((16, 16, 4), numpy.uint8)
+    view = buf[::-1]
+    # Sanity: the case under test. Same shape and dtype, data pointer at
+    # the far end of the allocation.
+    assert view.shape == buf.shape and view.dtype == buf.dtype
+    assert not view.flags["C_CONTIGUOUS"]
+    assert view.ctypes.data > buf.ctypes.data
+    _reject(backend, gdi32, view, ValueError, "C-contiguous")
+
+
+def test_strided_view_is_rejected(make_backend):
+    backend, _user32, gdi32 = make_backend()
+    view = numpy.zeros((8, 32, 4), numpy.uint8)[:, ::2]
+    assert not view.flags["C_CONTIGUOUS"]
+    _reject(backend, gdi32, view, ValueError, "C-contiguous")
+
+
+def test_read_only_buffer_is_rejected(make_backend):
+    backend, _user32, gdi32 = make_backend()
+    buf = numpy.zeros((8, 8, 4), numpy.uint8)
+    buf.flags.writeable = False
+    _reject(backend, gdi32, buf, ValueError, "writable")
+
+
+def test_wrong_channel_count_is_rejected(make_backend):
+    # Regression shape: (8, 8, 3) is 192 bytes but the copy writes 256.
+    backend, _user32, gdi32 = make_backend()
+    _reject(backend, gdi32, numpy.zeros((8, 8, 3), numpy.uint8),
+            ValueError, r"height, width, 4")
+
+
+def test_non_3d_buffer_is_rejected(make_backend):
+    backend, _user32, gdi32 = make_backend()
+    _reject(backend, gdi32, numpy.zeros((8, 8), numpy.uint8),
+            ValueError, r"height, width, 4")
+
+
+def test_wrong_dtype_is_rejected(make_backend):
+    backend, _user32, gdi32 = make_backend()
+    _reject(backend, gdi32, numpy.zeros((8, 8, 4), numpy.float64),
+            ValueError, "dtype uint8")
+
+
+def test_non_array_is_rejected(make_backend):
+    backend, _user32, gdi32 = make_backend()
+    _reject(backend, gdi32, [[0, 0, 0, 0]], TypeError, "ndarray")
+
+
+def test_empty_buffer_is_rejected(make_backend):
+    backend, _user32, gdi32 = make_backend()
+    _reject(backend, gdi32, numpy.zeros((0, 8, 4), numpy.uint8),
+            ValueError, "positive")
+
+
+def test_a_valid_destination_still_captures(make_backend):
+    # The guard must not have made the ordinary path stricter.
+    backend, user32, gdi32 = make_backend()
+    img = _capture(backend, 0, 0, 12, 10)
+    assert img.shape == (10, 12, 4)
+    assert len(gdi32.blits) == 1
+    assert numpy.array_equal(img, user32.screen[0:10, 0:12])


### PR DESCRIPTION
`WindowsBackend.screenshot()` ends in a raw `ctypes.memmove`, which walks
`height * width * 4` bytes forward from the destination's data pointer and knows
nothing about strides. Nothing validated that destination.

```python
WindowsBackend().screenshot(0, 0, numpy.empty((100, 100, 4), numpy.uint8)[::-1])
```

That view has the documented shape and dtype, but `arr[::-1]` puts its data pointer
at the **last row** of the allocation. The copy then writes 40,000 bytes *forward*
from there, straight off the end of the buffer.

## Demonstrated, not argued

Removing the new guard and running the suite:

```
Segmentation fault (core dumped)
```

This reproduces on Linux under the existing mocked-ctypes tests, because the defect
is in the Python-level `memmove` call rather than in anything Win32 does — the fakes
model the copy faithfully.

## Why only this backend

| backend | how it fills the caller's array | exposed? |
|---|---|---|
| x11 | C extension, validates every case | no |
| macos | `img[:] = src[...]` | no — numpy is stride-aware, and refuses read-only |
| wlr | `img[:] = arr[...]` | no — same |
| **windows** | **`ctypes.memmove(img.ctypes.data, …)`** | **yes** |

The X11 C extension has validated all of this since it was written, with tests for
non-contiguous, read-only, wrong-dtype, wrong-channel-count and non-array
destinations. Windows never gained the equivalent, so the directly-callable backend
API — which `examples/low_level_api_screenshot.py` advertises — meant different
things on different platforms.

## Fix

`_validate_destination()` mirrors the C extension's checks *and its wording*, so the
two now agree:

* must be a `numpy.ndarray` → `TypeError`
* `(height, width, 4)` → `ValueError`
* `dtype uint8` → `ValueError`
* C-contiguous, aligned and writable → `ValueError`
* positive height and width → `ValueError`

Rejected rather than coerced, matching X11's existing choice: a coerced copy would be
filled and then dropped on the floor.

## Tests

Nine cases, each asserting the call is refused **and** that `gdi32.blits == []` — so
nothing touches the screen before the destination is known safe. The reversed-view
test additionally asserts the preconditions that make it dangerous (same shape and
dtype as a valid buffer, non-contiguous, data pointer above the allocation's start),
so it cannot quietly stop testing the real thing.

Plus one test that an ordinary contiguous destination still captures correctly, since
a guard is also a chance to break the normal path.

`docker compose run --rm test` -> **294 passed** (was 285).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLmJd7aNG8CRS7EQ9waLqD
