### PR TITLE
wlr: refuse a pre-v3 compositor and a non-BGRA buffer format

### DIFF
--- a/fastgrab/backends/wlr.py
+++ b/fastgrab/backends/wlr.py
@@ -80,7 +80,7 @@ class _OutputState:
 class _FrameState:
     """Per-capture event accumulator."""
     __slots__ = ("fmt", "w", "h", "stride", "buffer_done",
-                 "flags", "ready", "failed")
+                 "flags", "ready", "failed", "offered")
 
     def __init__(self):
         self.fmt = None
@@ -91,6 +91,9 @@ class _FrameState:
         self.flags = 0
         self.ready = False
         self.failed = False
+        # Formats the compositor offered that are not BGRA in memory,
+        # kept so a refusal can name them.
+        self.offered = []
 
 
 class _RegionPlan:
@@ -225,6 +228,9 @@ class WlrBackend(BaseBackend):
         outputs = []
         shm = [None]
         screencopy = [None]
+        # Set instead of binding when the advertised screencopy version is
+        # too old for the handshake below, so the refusal can name it.
+        screencopy_version = [None]
         xdg_output_manager = [None]
 
         def _on_global(registry, name, interface, version):
@@ -251,6 +257,18 @@ class WlrBackend(BaseBackend):
             elif interface == "wl_shm":
                 shm[0] = registry.bind(name, WlShm, min(version, 1))
             elif interface == "zwlr_screencopy_manager_v1":
+                # The capture loop waits for `buffer_done`, which the
+                # protocol only introduced in version 3. Bound below
+                # that, the compositor sends `buffer` and then waits for
+                # `copy` while we wait for an event it will never send --
+                # a capture that blocks forever rather than failing.
+                # wlroots has shipped version 3 since 2020, so refusing
+                # is proportionate; supporting the legacy handshake would
+                # mean an untestable code path for compositors that
+                # effectively no longer exist.
+                if version < _FRAME_VERSION:
+                    screencopy_version[0] = version
+                    return
                 screencopy[0] = registry.bind(
                     name, ZwlrScreencopyManagerV1, min(version, _FRAME_VERSION)
                 )
@@ -275,6 +293,15 @@ class WlrBackend(BaseBackend):
         display.roundtrip()
         display.roundtrip()  # let mode/name/done + logical_size settle
 
+        if screencopy[0] is None and screencopy_version[0] is not None:
+            raise RuntimeError(
+                "compositor advertises zwlr_screencopy_manager_v1 version "
+                "{}, but fastgrab needs version {}: the capture handshake "
+                "waits for the `buffer_done` event, which the protocol only "
+                "added in version 3. Binding lower would block forever "
+                "waiting for an event the compositor never sends."
+                .format(screencopy_version[0], _FRAME_VERSION)
+            )
         if screencopy[0] is None:
             raise RuntimeError(
                 "compositor does not advertise zwlr_screencopy_manager_v1; "
@@ -459,6 +486,20 @@ class WlrBackend(BaseBackend):
         if state.failed:
             frame.destroy()
             raise RuntimeError("wlr-screencopy frame failed before buffer info")
+        if state.fmt is None:
+            # Every offered format had a memory layout that is not BGRA.
+            # Refused by name rather than copied out as if it were: an
+            # ABGR8888 frame read as BGRA returns red pixels as blue.
+            offered = ", ".join(
+                "0x{:08x}".format(f) for f in state.offered
+            ) or "none"
+            frame.destroy()
+            raise RuntimeError(
+                "compositor offered no BGRA-compatible buffer format for "
+                "this frame (offered: {}). fastgrab needs "
+                "WL_SHM_FORMAT_ARGB8888 (0) or WL_SHM_FORMAT_XRGB8888 (1), "
+                "whose bytes are already B, G, R, A.".format(offered)
+            )
 
         # Check the size the compositor actually returned rather than
         # trusting the scale it announced. wl_output.scale is an integer
@@ -521,11 +562,25 @@ class WlrBackend(BaseBackend):
 
     @staticmethod
     def _on_frame_buffer(state, fmt, w, h, stride):
-        # Prefer the SHM buffer event over linux_dmabuf — we always use SHM.
-        if state.fmt is None or fmt in (
-            _WL_SHM_FORMAT_ARGB8888,
-            _WL_SHM_FORMAT_XRGB8888,
-        ):
+        """Accept only a format whose memory layout is already BGRA.
+
+        A version-3 compositor sends one of these per supported buffer
+        type, so this runs several times and must pick, not merely
+        record. ARGB8888 and XRGB8888 are 32-bit little-endian words, so
+        their bytes land B, G, R, A — exactly the public contract.
+
+        The previous condition began ``state.fmt is None or ...``, which
+        accepted whatever arrived *first* whether or not it was one of
+        those. A compositor offering ABGR8888 (bytes R, G, B, A) had its
+        frames copied out as if they were BGRA, so red came back as blue.
+        Every other format is refused by name in ``screenshot()`` rather
+        than silently mis-read.
+        """
+        if fmt not in (_WL_SHM_FORMAT_ARGB8888, _WL_SHM_FORMAT_XRGB8888):
+            state.offered.append(fmt)
+            return
+        # Both are BGRA in memory; keep the first acceptable one.
+        if state.fmt is None:
             state.fmt = fmt
             state.w = w
             state.h = h

--- a/tests/test_wlr_backend.py
+++ b/tests/test_wlr_backend.py
@@ -252,8 +252,9 @@ def test_full_output_capture_is_never_blocked_by_the_guard(output):
 class _FakeFrame:
     """A zwlr_screencopy_frame_v1 that reports a fixed buffer size."""
 
-    def __init__(self, w, h, pixels=None, flags=0):
+    def __init__(self, w, h, pixels=None, flags=0, fmts=(0,)):
         self.dispatcher = {}
+        self.fmts = fmts
         self.w, self.h = w, h
         self.pixels = pixels
         self.flags = flags
@@ -261,8 +262,10 @@ class _FakeFrame:
         self.copied = False
 
     def deliver_buffer(self):
-        # wl_shm ARGB8888 is format 0.
-        self.dispatcher["buffer"](self, 0, self.w, self.h, self.w * 4)
+        # A version-3 compositor sends one buffer event per supported
+        # format, then buffer_done. wl_shm ARGB8888 is 0, XRGB8888 is 1.
+        for fmt in self.fmts:
+            self.dispatcher["buffer"](self, fmt, self.w, self.h, self.w * 4)
         if self.flags:
             self.dispatcher["flags"](self, self.flags)
         self.dispatcher["buffer_done"](self)
@@ -483,3 +486,127 @@ def test_full_output_capture_still_copies_the_whole_frame():
 
     assert requests == [("full",)]
     _assert_is_frame_window(img, upright, 0, 0)
+
+
+# -------- buffer format negotiation --------
+#
+# _on_frame_buffer used to begin `if state.fmt is None or fmt in (...)`,
+# so whatever arrived *first* was taken whether or not its bytes were
+# BGRA. ABGR8888 frames were copied out as if they were BGRA, turning
+# red pixels blue.
+
+_ABGR8888 = 0x34324241  # DRM fourcc 'AB24'; bytes are R, G, B, A
+_XRGB8888 = 1
+_ARGB8888 = 0
+
+
+def test_a_format_that_is_not_bgra_is_refused_by_name():
+    backend, frame = _capture_backend(_output(), frame_w=100, frame_h=50)
+    frame.fmts = (_ABGR8888,)
+    with pytest.raises(RuntimeError, match=r"no BGRA-compatible buffer format"):
+        backend.screenshot(0, 0, numpy.zeros((50, 100, 4), numpy.uint8))
+    assert frame.destroyed, "the frame must be released on the error path"
+
+
+def test_the_refusal_names_the_format_that_was_offered():
+    backend, frame = _capture_backend(_output(), frame_w=100, frame_h=50)
+    frame.fmts = (_ABGR8888,)
+    with pytest.raises(RuntimeError, match=r"0x34324241"):
+        backend.screenshot(0, 0, numpy.zeros((50, 100, 4), numpy.uint8))
+
+
+def _state_after(*fmts):
+    """Feed buffer events to a fresh frame state, as a compositor would."""
+    from fastgrab.backends.wlr import _FrameState
+
+    state = _FrameState()
+    for fmt in fmts:
+        WlrBackend._on_frame_buffer(state, fmt, 100, 50, 400)
+    return state
+
+
+def test_a_non_bgra_format_is_never_chosen():
+    state = _state_after(_ABGR8888)
+    assert state.fmt is None, "ABGR8888 bytes are R,G,B,A — not the contract"
+    assert state.offered == [_ABGR8888]
+
+
+def test_an_acceptable_format_is_taken_even_if_offered_second():
+    # The realistic shape: a v3 compositor advertising several types.
+    state = _state_after(_ABGR8888, _XRGB8888)
+    assert state.fmt == _XRGB8888
+    assert state.offered == [_ABGR8888]
+
+
+def test_the_first_acceptable_format_wins():
+    state = _state_after(_ARGB8888, _XRGB8888)
+    assert state.fmt == _ARGB8888
+
+
+@pytest.mark.parametrize("fmt", [_ARGB8888, _XRGB8888])
+def test_both_bgra_formats_are_accepted(fmt):
+    state = _state_after(fmt)
+    assert state.fmt == fmt
+    assert state.stride == 400
+
+
+# -------- screencopy version negotiation --------
+
+
+class _FakeRegistry:
+    def __init__(self, advertised):
+        self.dispatcher = {}
+        self._advertised = advertised
+        self._emitted = False
+
+    def emit(self):
+        if self._emitted:
+            return
+        self._emitted = True
+        for name, (interface, version) in enumerate(self._advertised):
+            self.dispatcher["global"](self, name, interface, version)
+
+    def bind(self, name, cls, version):
+        return SimpleNamespace(dispatcher={})
+
+
+def _connect_against(advertised, monkeypatch):
+    """Drive _connect_singleton over a registry advertising `advertised`."""
+    from fastgrab.backends import wlr as wlr_mod
+
+    registry = _FakeRegistry(advertised)
+
+    class _FakeDisplay:
+        def connect(self):
+            pass
+
+        def get_registry(self):
+            return registry
+
+        def roundtrip(self):
+            registry.emit()
+
+    monkeypatch.setattr(wlr_mod, "Display", lambda *a, **kw: _FakeDisplay())
+    # The connection is a process-wide singleton; do not leave ours behind.
+    monkeypatch.setattr(wlr_mod, "_SINGLETON_STATE", None, raising=False)
+    return wlr_mod.WlrBackend._connect_singleton()
+
+
+def test_a_pre_v3_screencopy_compositor_is_refused_not_hung(monkeypatch):
+    """Binding below version 3 would block forever, not fail.
+
+    The capture loop waits for ``buffer_done``, which the protocol only
+    added in version 3. A v1/v2 compositor sends ``buffer`` and then
+    waits for ``copy`` while we wait for an event it will never send.
+    """
+    with pytest.raises(RuntimeError, match=r"version 2.*needs version 3"):
+        _connect_against(
+            [("zwlr_screencopy_manager_v1", 2), ("wl_shm", 1)], monkeypatch
+        )
+
+
+def test_the_pre_v3_refusal_explains_buffer_done(monkeypatch):
+    with pytest.raises(RuntimeError, match=r"buffer_done"):
+        _connect_against(
+            [("zwlr_screencopy_manager_v1", 1), ("wl_shm", 1)], monkeypatch
+        )


### PR DESCRIPTION
Two defects in the same screencopy handshake. Both are invisible under `cage`,
which advertises version 3 and offers an acceptable format.

## 1. A pre-v3 compositor hung forever instead of failing

`_connect_singleton()` bound the manager at `min(version, 3)` — so a compositor
advertising version 1 or 2 was bound at *its* version. The capture loop then waits
for `buffer_done`:

```python
while not state.buffer_done and not state.failed:
    self._display.dispatch(block=True)
```

and the generated binding says exactly when that event exists:

```python
@ZwlrScreencopyFrameV1.event(version=3)
def buffer_done(self) -> None:
```

Below version 3 the compositor sends `buffer` and then waits for `copy`, while
fastgrab waits for an event it will never send. **The capture blocks forever** —
no error, no timeout, just a hung process.

Now refused at bind time, naming both versions and the reason. wlroots has shipped
version 3 since 2020, so supporting the legacy handshake would mean carrying a code
path no CI could exercise, for compositors that effectively no longer exist. A
clear error beats a hang, and beats untested code.

## 2. A non-BGRA format was read as BGRA — red came back blue

```python
if state.fmt is None or fmt in (_WL_SHM_FORMAT_ARGB8888,
                                _WL_SHM_FORMAT_XRGB8888):
```

The `state.fmt is None` arm accepts whatever arrives **first**, whatever it is. A
version-3 compositor sends one `buffer` event per supported type, so this is a
choice, not a recording — and it was making the wrong one whenever the first offer
was not one of the two acceptable formats.

* `ARGB8888` / `XRGB8888` are 32-bit little-endian words → bytes **B, G, R, A** —
  the public contract.
* `ABGR8888` → bytes **R, G, B, A**.

A compositor offering only `ABGR8888` had its frames copied out as if they were
BGRA, so a red pixel `(255, 0, 0, 255)` was returned as blue. Silently: no error,
no warning, just wrong colours.

Non-BGRA formats are now recorded and refused **by name**:

```
compositor offered no BGRA-compatible buffer format for this frame
(offered: 0x34324241). fastgrab needs WL_SHM_FORMAT_ARGB8888 (0) or
WL_SHM_FORMAT_XRGB8888 (1), whose bytes are already B, G, R, A.
```

Refusing rather than swizzling is deliberate: a conversion path no compositor here
can exercise is exactly the untested code this project avoids. If someone reports
an ABGR-only compositor, a swizzle is a small, targeted follow-up — and it would
then have a real user to verify it.

## Tests

Format choice is driven through `_on_frame_buffer` directly, since that is the
function that changed and a full capture would need a much heavier fake for no
extra coverage: a non-BGRA format is never chosen, an acceptable one is taken even
when offered second, the first acceptable one wins, and both acceptable formats are
accepted. Plus two end-to-end refusals through `screenshot()` that check the frame
is released on the error path.

Version negotiation is driven through `_connect_singleton()` over a fake registry
advertising version 2, with the process-wide connection singleton monkeypatched so
the test cannot leave one behind.

Controls, both run against the committed fix:

* restoring the old format condition → **5 failed**
* removing the version refusal → **2 failed**

`docker compose run --rm test` -> **305 passed** (was 296);
`test-wayland` -> **23 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLmJd7aNG8CRS7EQ9waLqD
