### PR TITLE
backends: free the frame buffer when a Screenshot is dropped

### DIFF
--- a/fastgrab/backends/base.py
+++ b/fastgrab/backends/base.py
@@ -51,6 +51,36 @@ from abc import ABC, abstractmethod
 
 
 class BaseBackend(ABC):
+    _closed = False
+    """Set on the instance by :meth:`close`; a class attribute so that a
+    backend needs no ``__init__`` of its own to have one."""
+
+    def close(self):
+        """Release any OS resources this backend holds.
+
+        The default is a no-op, which is right for a backend that keeps
+        nothing between calls: ``x11`` shares one process-wide connection
+        owned by the C extension, and ``macos`` re-resolves the display
+        every time. A backend that allocates a frame buffer per instance
+        — ``wlr``'s SHM buffer, ``windows``' DIBSection — overrides this
+        and must also refuse to capture afterwards, because the handles
+        it would blit through are gone.
+
+        Closing is optional. Each such backend keeps its handles in a
+        small helper object carrying a :mod:`weakref` finalizer, so
+        dropping the backend frees them too; ``close`` only makes the
+        moment deterministic. It must be safe to call twice.
+        """
+        self._closed = True
+
+    def _check_open(self):
+        """Raise if :meth:`close` has already run."""
+        if self._closed:
+            raise RuntimeError(
+                "this backend has been closed; construct a new "
+                "Screenshot() rather than reusing a closed one"
+            )
+
     @abstractmethod
     def resolution(self):
         """Return ``(width, height)`` of the primary screen/output.

--- a/fastgrab/backends/windows.py
+++ b/fastgrab/backends/windows.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import contextlib
 import ctypes
+import weakref
 from ctypes import wintypes  # only available on Windows; gated by importer
 
 import numpy
@@ -193,6 +194,76 @@ def _validate_destination(img):
         raise ValueError("image buffer height and width must be positive")
 
 
+def _release_gdi(state):
+    """Delete a memory DC and the DIBSection selected into it.
+
+    Order is forced by GDI: a bitmap that is still selected into a DC
+    cannot be deleted, so the DC's original bitmap goes back first, and
+    the DC itself is deleted last because it is what the bitmap was
+    selected into.
+
+    ``state`` is a :class:`_GdiSurface`'s attribute dict — see that class
+    for why the handles arrive by dict rather than by value. Nothing here
+    raises: it runs from a finalizer, and these calls only report failure
+    through a return code anyway.
+    """
+    gdi32 = state.get("gdi32")
+    if gdi32 is None:
+        return
+    mem_dc = state.get("mem_dc")
+    bitmap = state.get("bitmap")
+    old_obj = state.get("old_obj")
+    if bitmap:
+        if old_obj:
+            gdi32.SelectObject(mem_dc, old_obj)
+        gdi32.DeleteObject(bitmap)
+    if mem_dc:
+        gdi32.DeleteDC(mem_dc)
+    state["bitmap"] = None
+    state["old_obj"] = None
+    state["bits_ptr"] = None
+    state["mem_dc"] = None
+
+
+class _GdiSurface:
+    """Owns one backend's memory DC and its current DIBSection.
+
+    Freeing both when this object is dropped is what bounds the
+    backend's GDI handles to its own lifetime without putting a
+    ``__del__`` on the backend. GDI's per-process quota is 10,000
+    handles, but the DIBSection's pixels leak along with the handle — at
+    1080p that is ~8 MB apiece, so a program that builds a Screenshot per
+    frame runs out of memory long before it runs out of handles.
+
+    The finalizer is handed this instance's ``__dict__`` rather than the
+    handles themselves. ``weakref.finalize`` freezes its arguments at
+    registration time, and ``bitmap`` is replaced every time the capture
+    size changes, so passing the handle would free a stale one and leak
+    the live one. The attribute dict outlives the instance and always
+    reads back what is currently open. It must not be handed ``self`` —
+    a finalizer that references its own object can never run.
+
+    ``atexit`` is off: at interpreter shutdown Windows reclaims every
+    handle the process owns, and running GDI calls that late is exactly
+    the race the backend's old "no ``__del__``" note was avoiding.
+    """
+
+    def __init__(self, gdi32, mem_dc):
+        self.gdi32 = gdi32
+        self.mem_dc = mem_dc
+        self.bitmap = None      # HBITMAP
+        self.old_obj = None     # HGDIOBJ displaced by SelectObject
+        self.bits_ptr = None    # raw pointer into the DIBSection's pixels
+        self.w = 0
+        self.h = 0
+        self._finalize = weakref.finalize(self, _release_gdi, self.__dict__)
+        self._finalize.atexit = False
+
+    def close(self):
+        """Free now. Idempotent — a finalizer only ever fires once."""
+        self._finalize()
+
+
 class WindowsBackend(BaseBackend):
     def __init__(self):
         self._user32, self._gdi32 = _load_libs()
@@ -207,18 +278,17 @@ class WindowsBackend(BaseBackend):
             if not screen_dc:
                 raise RuntimeError("GetDC(NULL) returned 0; cannot access screen")
             try:
-                self._mem_dc = self._gdi32.CreateCompatibleDC(screen_dc)
+                mem_dc = self._gdi32.CreateCompatibleDC(screen_dc)
             finally:
                 self._user32.ReleaseDC(None, screen_dc)
-        if not self._mem_dc:
+        if not mem_dc:
             raise RuntimeError("CreateCompatibleDC failed")
 
-        # cached DIBSection state — reused when (w, h) match the prior call.
-        self._cur_w = 0
-        self._cur_h = 0
-        self._cur_bitmap = None     # HBITMAP
-        self._cur_old_obj = None    # HGDIOBJ returned by SelectObject
-        self._cur_bits_ptr = None   # raw pointer into the DIBSection's pixels
+        # The DC and the DIBSection cached against it are held by a
+        # separate owner so that dropping this backend frees them; see
+        # _GdiSurface. The bitmap is reused whenever (w, h) match the
+        # previous call.
+        self._surface = _GdiSurface(self._gdi32, mem_dc)
 
     # -------- BaseBackend API --------
 
@@ -244,6 +314,7 @@ class WindowsBackend(BaseBackend):
     def screenshot(self, x, y, img):
         # Before anything touches the screen: the copy at the end is a
         # raw memmove and cannot recover from a bad destination.
+        self._check_open()
         _validate_destination(img)
         h, w, _ = img.shape
         self._ensure_bitmap(w, h)
@@ -265,7 +336,7 @@ class WindowsBackend(BaseBackend):
                 raise RuntimeError("GetDC(NULL) returned 0; cannot access screen")
             try:
                 ok = self._gdi32.BitBlt(
-                    self._mem_dc, 0, 0, w, h,
+                    self._surface.mem_dc, 0, 0, w, h,
                     screen_dc, int(x), int(y),
                     _SRCCOPY | _CAPTUREBLT,
                 )
@@ -278,22 +349,23 @@ class WindowsBackend(BaseBackend):
             raise RuntimeError("BitBlt failed (GetLastError={})".format(err))
 
         nbytes = w * h * 4
-        ctypes.memmove(img.ctypes.data, self._cur_bits_ptr, nbytes)
+        ctypes.memmove(img.ctypes.data, self._surface.bits_ptr, nbytes)
 
     # -------- DIBSection cache --------
 
     def _ensure_bitmap(self, w, h):
-        if self._cur_bitmap is not None and (w, h) == (self._cur_w, self._cur_h):
+        surface = self._surface
+        if surface.bitmap is not None and (w, h) == (surface.w, surface.h):
             return
 
         # Tear down previous bitmap.
-        if self._cur_bitmap is not None:
-            if self._cur_old_obj is not None:
-                self._gdi32.SelectObject(self._mem_dc, self._cur_old_obj)
-            self._gdi32.DeleteObject(self._cur_bitmap)
-            self._cur_bitmap = None
-            self._cur_old_obj = None
-            self._cur_bits_ptr = None
+        if surface.bitmap is not None:
+            if surface.old_obj is not None:
+                self._gdi32.SelectObject(surface.mem_dc, surface.old_obj)
+            self._gdi32.DeleteObject(surface.bitmap)
+            surface.bitmap = None
+            surface.old_obj = None
+            surface.bits_ptr = None
 
         bmi = _BITMAPINFO()
         bmi.bmiHeader.biSize = ctypes.sizeof(_BITMAPINFOHEADER)
@@ -308,7 +380,7 @@ class WindowsBackend(BaseBackend):
 
         bits_ptr = ctypes.c_void_p()
         bitmap = self._gdi32.CreateDIBSection(
-            self._mem_dc,
+            surface.mem_dc,
             ctypes.byref(bmi),
             _DIB_RGB_COLORS,
             ctypes.byref(bits_ptr),
@@ -322,18 +394,27 @@ class WindowsBackend(BaseBackend):
                 )
             )
 
-        old_obj = self._gdi32.SelectObject(self._mem_dc, bitmap)
+        old_obj = self._gdi32.SelectObject(surface.mem_dc, bitmap)
         if not old_obj:
             self._gdi32.DeleteObject(bitmap)
             raise RuntimeError("SelectObject failed for new DIBSection")
 
-        self._cur_bitmap = bitmap
-        self._cur_old_obj = old_obj
-        self._cur_bits_ptr = bits_ptr.value
-        self._cur_w = w
-        self._cur_h = h
+        surface.bitmap = bitmap
+        surface.old_obj = old_obj
+        surface.bits_ptr = bits_ptr.value
+        surface.w = w
+        surface.h = h
 
-    # No __del__: matching the wlr backend, we let the OS reclaim the
-    # memory DC and bitmap handles at process exit. Explicit cleanup
-    # paths are race-prone under interpreter shutdown. The screen DC is
-    # no longer among them — it is released on every capture.
+    def close(self):
+        """Release the memory DC and the DIBSection selected into it.
+
+        Optional — dropping the backend frees the same handles through
+        :class:`_GdiSurface`'s finalizer. Call it to pick the moment.
+
+        Still no ``__del__`` on the backend: explicit cleanup driven from
+        interpreter shutdown is the race the old note here warned about,
+        and the finalizer deliberately does not run then. The screen DC
+        was never among these handles — it is released on every capture.
+        """
+        self._surface.close()
+        self._closed = True

--- a/fastgrab/backends/wlr.py
+++ b/fastgrab/backends/wlr.py
@@ -19,6 +19,7 @@ conversion and exactly what it is allowed to assume.
 """
 import mmap
 import os
+import weakref
 import struct  # noqa: F401  (reserved for future DMA-BUF / extended formats)
 
 import numpy as np
@@ -191,6 +192,83 @@ def _plan_region(x, y, w, h, mode_w, mode_h, logical_w, logical_h):
         exp_w=lw * scale,
         exp_h=lh * scale,
     )
+
+
+def _release_shm(mm, fd, wl_buffer):
+    """Free one SHM frame buffer: the compositor's claim first, then ours.
+
+    The order is the whole point. A ``wl_buffer`` the compositor still
+    owns keeps the compositor's own mapping of the memfd alive, so
+    closing our file descriptor first releases no memory at all —
+    measured against cage, 50 dropped buffers held 175.5 MiB of system
+    Shmem, and closing every descriptor by hand freed none of it. Sending
+    ``destroy`` brought the same 50 down to 0.8 MiB.
+
+    Nothing here may raise. This runs from a :mod:`weakref` finalizer,
+    where an exception is printed and swallowed at an arbitrary point in
+    someone else's call stack. A dead connection is not a leak either —
+    the compositor drops every resource it held for us when the socket
+    closes.
+    """
+    try:
+        wl_buffer.destroy()
+    except Exception:
+        pass
+    try:
+        mm.close()
+    except Exception:
+        pass
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+
+
+class _ShmBuffer:
+    """Owns one memfd + mmap + wl_buffer, and frees them when dropped.
+
+    The finalizer lives here rather than on :class:`WlrBackend` so that
+    dropping a backend releases its frame buffer without the backend
+    needing a ``__del__``. That separation is the point: the backend is
+    entangled with pywayland's connection-wide state, whose finalisation
+    order at interpreter shutdown is exactly what makes ``__del__``
+    unsafe here, while these three handles are this object's own and
+    nobody else's.
+
+    ``atexit`` is turned off for the same reason. At shutdown the kernel
+    reclaims the descriptor and the mapping regardless, and the
+    compositor frees everything when the socket closes, so firing then
+    buys nothing and would push a request through a display that may
+    already be half torn down. The leak worth fixing is the one that
+    accumulates *while* the process runs.
+    """
+
+    # __weakref__ is not optional here: weakref.finalize takes a weak
+    # reference to this object, and a __slots__ class does not get one
+    # unless it is asked for. Without it construction raises outright.
+    __slots__ = ("mm", "fd", "wl", "w", "h", "stride", "fmt", "_finalize",
+                 "__weakref__")
+
+    def __init__(self, mm, fd, wl, w, h, stride, fmt):
+        self.mm = mm
+        self.fd = fd
+        self.wl = wl
+        self.w = w
+        self.h = h
+        self.stride = stride
+        self.fmt = fmt
+        # The finalizer is handed the raw handles, never ``self``: a
+        # finalizer that referenced its own object would keep that object
+        # reachable and so could never run.
+        self._finalize = weakref.finalize(self, _release_shm, mm, fd, wl)
+        self._finalize.atexit = False
+
+    def matches(self, w, h, stride, fmt):
+        return (self.w, self.h, self.stride, self.fmt) == (w, h, stride, fmt)
+
+    def close(self):
+        """Free now. Idempotent — a finalizer only ever fires once."""
+        self._finalize()
 
 
 # The wayland connection + globals are shared across all WlrBackend
@@ -447,6 +525,7 @@ class WlrBackend(BaseBackend):
         return _RegionPlan((x, y, w, h), 0, 0, w, h)
 
     def screenshot(self, x, y, img):
+        self._check_open()
         h, w, _ = img.shape
         full_w, full_h = self.resolution()
         if x == 0 and y == 0 and w == full_w and h == full_h:
@@ -607,13 +686,9 @@ class WlrBackend(BaseBackend):
     def _ensure_buffer(self, fmt, w, h, stride):
         """Reuse the SHM-backed wl_buffer if dimensions match the last call."""
         if self._buf is not None:
-            old_mm, old_fd, old_wl, old_w, old_h, old_stride, old_fmt = self._buf
-            if (old_w, old_h, old_stride, old_fmt) == (w, h, stride, fmt):
-                return old_wl, old_mm
-            # dispose of old
-            old_wl.destroy()
-            old_mm.close()
-            os.close(old_fd)
+            if self._buf.matches(w, h, stride, fmt):
+                return self._buf.wl, self._buf.mm
+            self._buf.close()
             self._buf = None
 
         size = stride * h
@@ -625,9 +700,21 @@ class WlrBackend(BaseBackend):
         wl_buffer = pool.create_buffer(0, w, h, stride, fmt)
         pool.destroy()
 
-        self._buf = (mm, fd, wl_buffer, w, h, stride, fmt)
+        self._buf = _ShmBuffer(mm, fd, wl_buffer, w, h, stride, fmt)
         return wl_buffer, mm
 
-    # Intentionally no __del__ — pywayland's C-level state has its own
-    # lifecycle and finalising in arbitrary GC order can segfault. The
-    # OS reclaims the fd / mmap when the process exits.
+    def close(self):
+        """Release this instance's SHM frame buffer.
+
+        Optional — dropping the backend frees the same buffer through
+        :class:`_ShmBuffer`'s finalizer. Call it to pick the moment.
+
+        Still no ``__del__`` on the backend itself: pywayland's C-level
+        state has its own lifecycle and finalising it in arbitrary GC
+        order can segfault. Only the buffer is ours to free; the display
+        is process-wide and outlives every instance.
+        """
+        if self._buf is not None:
+            self._buf.close()
+            self._buf = None
+        self._closed = True

--- a/fastgrab/screenshot.py
+++ b/fastgrab/screenshot.py
@@ -30,6 +30,9 @@ class Screenshot(object):
         self._img = None
         """The buffer where the captured image is stored"""
 
+        self._closed = False
+        """Set by :meth:`close`; capture refuses to run afterwards"""
+
     @property
     def screensize(self) -> tuple:
         """
@@ -236,6 +239,11 @@ class Screenshot(object):
          BGRA byte order.
         """
 
+        if self._closed:
+            raise RuntimeError(
+                "this Screenshot has been closed; construct a new one"
+            )
+
         # check/set the dimensions of the image that will be captured
         if bbox is None:
             width, height = self.screensize
@@ -263,3 +271,41 @@ class Screenshot(object):
         self._backend.screenshot(x, y, self._img)
 
         return self._img
+
+    def close(self):
+        """Release the backend's OS resources and drop the image buffer.
+
+        Optional. Every backend that holds an OS-level frame buffer — the
+        wlr SHM buffer, the Windows DIBSection and its memory DC — keeps
+        it in a helper object carrying a :mod:`weakref` finalizer, so
+        simply dropping a ``Screenshot`` releases the same resources.
+        What ``close`` adds is the *moment*: the release happens here
+        rather than whenever the garbage collector gets to it.
+
+        That matters most for the shortest form of this library's API,
+        which throws the object away by construction::
+
+            img = screenshot.Screenshot().capture()
+
+        In a loop that is a new backend, and a new frame buffer, every
+        iteration. CPython frees each one promptly on refcount zero, but
+        code holding instances in a container, a cycle, or another
+        implementation's deferred collector will not. Reuse one
+        ``Screenshot``, or close what you finish with::
+
+            with screenshot.Screenshot() as grab:
+                img = grab.capture()
+
+        Idempotent, and safe on a backend that holds nothing. The
+        instance must not be used for capture afterwards.
+        """
+        self._closed = True
+        self._img = None
+        self._backend.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+        return False

--- a/tests/test_integration_wlr.py
+++ b/tests/test_integration_wlr.py
@@ -9,6 +9,8 @@ and assert on the resulting BGRA bytes.
 These tests are tagged with the ``wayland`` marker so they're excluded
 from the X11 test run and selected explicitly via ``-m wayland``.
 """
+import gc
+import os
 import time
 
 import numpy
@@ -222,3 +224,116 @@ def test_wlr_subregion_comes_from_the_right_place_when_scaled(
     ) == exact, "this parametrization is meant to exercise the other branch"
 
     _assert_subregion_matches_full_output(g, bbox)
+
+
+# -------- frame-buffer lifetime --------
+#
+# Each WlrBackend allocates a memfd-backed wl_buffer and nothing ever
+# freed it, so every Screenshot instance leaked one descriptor and one
+# frame's worth of memory. Measured before the fix, against cage: 76
+# leaked memfds after 76 instances, and with RLIMIT_NOFILE lowered to 64
+# the 43rd capture died with "OSError: [Errno 24] Too many open files".
+#
+# The memory is the worse half and is *not* ours to free directly. The
+# compositor keeps its own mapping for as long as it owns the wl_buffer,
+# so closing our descriptor releases nothing — 50 dropped buffers held
+# 175.5 MiB of system Shmem, and closing every fd by hand freed none of
+# it; the wl_buffer.destroy() requests brought it to 0.8 MiB. That is
+# asserted deterministically in tests/test_wlr_backend.py rather than
+# here, where it would mean reading a system-wide counter.
+
+# One live frame buffer accounts for *two* descriptors, not one:
+# os.memfd_create gives us ours, and mmap.mmap() dups it internally and
+# holds that copy until mm.close(). Both are freed together. Before the
+# fix, GC reclaimed the mmap (and so its dup) while the memfd itself was
+# never closed, which is why the leak measured one descriptor per
+# instance rather than two.
+_FDS_PER_BUFFER = 2
+
+
+def _fastgrab_memfds():
+    """Count this process's open ``fastgrab-wlr`` descriptors.
+
+    Collects first. Most tests in this module drop their backend without
+    closing it — the normal way to use the library — so an uncollected
+    buffer from an earlier test would otherwise sit in the baseline and
+    make these counts depend on test order.
+    """
+    gc.collect()
+    total = 0
+    for entry in os.listdir("/proc/self/fd"):
+        try:
+            target = os.readlink("/proc/self/fd/" + entry)
+        except OSError:
+            continue  # the descriptor closed under us; it is not a leak
+        if "fastgrab-wlr" in target:
+            total += 1
+    return total
+
+
+def test_a_capture_opens_one_frame_buffer():
+    """Baseline for the leak tests: one buffer per live backend."""
+    before = _fastgrab_memfds()
+    with _grab() as grab:
+        grab.capture((0, 0, 32, 32))
+        assert _fastgrab_memfds() == before + _FDS_PER_BUFFER
+    assert _fastgrab_memfds() == before
+
+
+def test_close_releases_the_frame_buffer_immediately():
+    before = _fastgrab_memfds()
+    grab = _grab()
+    try:
+        grab.capture((0, 0, 32, 32))
+    finally:
+        grab.close()
+    assert _fastgrab_memfds() == before
+
+
+def test_dropped_screenshot_objects_do_not_leak():
+    """The leak as a user meets it: no close(), just instances going away.
+
+    This is the shape of the library's headline API — the object in
+    ``Screenshot().capture()`` is unreachable the moment the expression
+    ends — so collection alone has to be enough.
+    """
+    before = _fastgrab_memfds()
+    for _ in range(20):
+        grab = _grab()
+        grab.capture((0, 0, 32, 32))
+        del grab
+    gc.collect()
+    assert _fastgrab_memfds() == before
+
+
+def test_the_two_line_api_in_a_loop_does_not_leak():
+    """Verbatim the form the README advertises, thirty times over."""
+    before = _fastgrab_memfds()
+    for _ in range(30):
+        screenshot.Screenshot(backend="wlr").capture((0, 0, 16, 16))
+    gc.collect()
+    assert _fastgrab_memfds() == before
+
+
+def test_resizing_within_one_instance_reuses_one_buffer():
+    """The resize path already freed correctly; keep it that way."""
+    before = _fastgrab_memfds()
+    with _grab() as grab:
+        for size in (16, 32, 64, 32, 16):
+            grab.capture((0, 0, size, size))
+            assert _fastgrab_memfds() == before + _FDS_PER_BUFFER
+    assert _fastgrab_memfds() == before
+
+
+def test_a_closed_instance_does_not_disturb_a_live_one():
+    """The display is a process-wide singleton; the buffer is not."""
+    first, second = _grab(), _grab()
+    try:
+        first.capture((0, 0, 32, 32))
+        second.capture((0, 0, 32, 32))
+        first.close()
+        # The survivor keeps working, and still owns exactly one buffer.
+        assert second.capture((0, 0, 32, 32)).shape == (32, 32, 4)
+    finally:
+        first.close()
+        second.close()

--- a/tests/test_screenshot.py
+++ b/tests/test_screenshot.py
@@ -354,3 +354,75 @@ def test_capture_reallocates_buffer_when_size_changes():
     img2 = grab.capture(bbox=(0, 0, bw2, bh2))
     assert img1 is not img2
     assert img2.shape == (bh2, bw2, 4)
+
+
+# -------- close() and the context manager --------
+#
+# The resources at stake are per-backend (a wlr SHM buffer, a Windows
+# DIBSection and its memory DC), so what they actually free is asserted
+# in tests/test_integration_wlr.py and tests/test_windows_backend.py.
+# These cover the contract every platform shares.
+
+def test_close_is_idempotent():
+    grab = screenshot.Screenshot()
+    grab.capture((0, 0, 2, 2))
+    grab.close()
+    grab.close()
+
+
+def test_close_releases_the_image_buffer():
+    """The numpy buffer is the one resource Screenshot owns directly."""
+    grab = screenshot.Screenshot()
+    grab.capture((0, 0, 2, 2))
+    assert grab._img is not None
+    grab.close()
+    assert grab._img is None
+
+
+def test_capture_after_close_raises():
+    """Refusing beats the alternative on Windows.
+
+    A closed backend has deleted the memory DC its BitBlt targets, and
+    blitting through a freed GDI handle is undefined rather than an
+    error. Every backend refuses uniformly so the behaviour does not
+    depend on which one was autodetected.
+    """
+    grab = screenshot.Screenshot()
+    grab.capture((0, 0, 2, 2))
+    grab.close()
+    with pytest.raises(RuntimeError, match="closed"):
+        grab.capture((0, 0, 2, 2))
+
+
+def test_context_manager_yields_the_instance_and_closes_it():
+    with screenshot.Screenshot() as grab:
+        img = grab.capture((0, 0, 2, 2))
+        assert img.shape == (2, 2, 4)
+    assert grab._closed is True
+
+
+def test_context_manager_closes_on_an_exception():
+    """A capture that raises must still release the frame buffer."""
+    boom = RuntimeError("caller blew up")
+    try:
+        with screenshot.Screenshot() as grab:
+            raise boom
+    except RuntimeError as exc:
+        assert exc is boom
+    assert grab._closed is True
+
+
+def test_a_closed_screenshot_does_not_close_a_new_one():
+    """Backends share process-wide state; closing must stay per instance.
+
+    The wlr backend's display connection is a process-wide singleton, so
+    an over-broad close would take out every future instance too. This is
+    the cheap check that it does not.
+    """
+    first = screenshot.Screenshot()
+    first.capture((0, 0, 2, 2))
+    first.close()
+
+    second = screenshot.Screenshot()
+    assert second.capture((0, 0, 2, 2)).shape == (2, 2, 4)
+    second.close()

--- a/tests/test_windows_backend.py
+++ b/tests/test_windows_backend.py
@@ -29,6 +29,7 @@ backend's fakes do:
   ``AttributeError`` here just as it would there.
 """
 import ctypes
+import gc
 import sys
 import types
 
@@ -182,11 +183,24 @@ class _FakeGdi32:
         self.buffers = {}         # HBITMAP -> (ctypes buffer, w, h)
         self.created_bitmaps = []
         self.deleted_bitmaps = []
+        self.created_dcs = []
+        self.deleted_dcs = []
         self._bitmap_serial = 0
+        self._dc_serial = 0
 
     def CreateCompatibleDC(self, hdc):
         assert hdc, "a memory DC must be built from a live screen DC"
-        return 0x2000
+        # A distinct handle per call: a shared constant would hide a
+        # backend that deleted one instance's DC and kept using another's.
+        self._dc_serial += 1
+        mem_dc = 0x2000 + self._dc_serial
+        self.created_dcs.append(mem_dc)
+        return mem_dc
+
+    def DeleteDC(self, hdc):
+        assert hdc not in self.deleted_dcs, "the memory DC was deleted twice"
+        self.deleted_dcs.append(hdc)
+        return 1
 
     def CreateDIBSection(self, hdc, bmi, usage, bits_ptr, section, offset):
         # ctypes.byref() wraps the argument in a CArgObject; the fake
@@ -208,6 +222,13 @@ class _FakeGdi32:
         return previous
 
     def DeleteObject(self, hgdiobj):
+        # GDI refuses to delete a bitmap that is still selected into a
+        # DC, and returns failure rather than leaking loudly — which is
+        # precisely how a wrong teardown order becomes a silent leak.
+        assert hgdiobj != self.selected, \
+            "deleted a bitmap while it was still selected into the DC"
+        assert hgdiobj not in self.deleted_bitmaps, \
+            "the same bitmap was deleted twice"
         self.deleted_bitmaps.append(hgdiobj)
         return 1
 
@@ -594,3 +615,141 @@ def test_a_valid_destination_still_captures(make_backend):
     assert img.shape == (10, 12, 4)
     assert len(gdi32.blits) == 1
     assert numpy.array_equal(img, user32.screen[0:10, 0:12])
+
+
+# -------- GDI handle lifetime --------
+#
+# The bug: __init__ created a memory DC and screenshot() created a
+# DIBSection, and neither was ever freed. GDI's per-process quota is
+# 10,000 handles, but the DIBSection's pixels leak with the handle — at
+# 1080p ~8 MB apiece — so `Screenshot().capture()` in a loop exhausts
+# memory long before the handle count. The old code said so itself:
+# "No __del__: ... we let the OS reclaim the memory DC and bitmap
+# handles at process exit."
+
+def test_close_deletes_the_bitmap_and_the_memory_dc(make_backend):
+    backend, _, gdi32 = make_backend()
+    _capture(backend, 0, 0, 8, 8)
+    bitmap = backend._surface.bitmap
+    mem_dc = backend._surface.mem_dc
+    assert bitmap in gdi32.created_bitmaps
+    assert mem_dc in gdi32.created_dcs
+
+    backend.close()
+
+    assert bitmap in gdi32.deleted_bitmaps
+    assert mem_dc in gdi32.deleted_dcs
+
+
+def test_close_is_idempotent(make_backend):
+    """The fake asserts on a double delete, so this is a real check."""
+    backend, _, gdi32 = make_backend()
+    _capture(backend, 0, 0, 8, 8)
+    backend.close()
+    backend.close()
+    assert len(gdi32.deleted_dcs) == 1
+
+
+def test_close_before_any_capture_still_frees_the_memory_dc(make_backend):
+    """The DC is built in __init__, so it leaks even with no capture."""
+    backend, _, gdi32 = make_backend()
+    mem_dc = backend._surface.mem_dc
+    backend.close()
+    assert gdi32.deleted_dcs == [mem_dc]
+    assert gdi32.deleted_bitmaps == []
+
+
+def test_dropping_the_backend_frees_its_gdi_handles(make_backend):
+    """The leak itself: no close(), just let the backend go out of scope.
+
+    This is the shape the library's own headline API produces —
+    ``Screenshot().capture()`` keeps no reference to the backend — so
+    collection has to be enough on its own.
+    """
+    backend, _, gdi32 = make_backend()
+    _capture(backend, 0, 0, 8, 8)
+    bitmap = backend._surface.bitmap
+    mem_dc = backend._surface.mem_dc
+
+    del backend
+    gc.collect()
+
+    assert bitmap in gdi32.deleted_bitmaps, "the DIBSection outlived its backend"
+    assert mem_dc in gdi32.deleted_dcs, "the memory DC outlived its backend"
+
+
+def test_many_dropped_backends_leak_no_handles(make_backend):
+    """Twenty instances, none closed: every handle must come back."""
+    made = []
+    for _ in range(20):
+        backend, _, gdi32 = make_backend()
+        _capture(backend, 0, 0, 8, 8)
+        made.append(gdi32)
+        del backend
+    gc.collect()
+
+    for gdi32 in made:
+        assert sorted(gdi32.deleted_bitmaps) == sorted(gdi32.created_bitmaps)
+        assert sorted(gdi32.deleted_dcs) == sorted(gdi32.created_dcs)
+
+
+def test_the_finalizer_does_not_run_at_interpreter_exit(make_backend):
+    """Deliberate: GDI calls during shutdown are the race __del__ had.
+
+    Windows reclaims every handle a process owned when it exits, so
+    firing then buys nothing and runs ctypes calls through modules that
+    may already be torn down.
+    """
+    backend, _, _ = make_backend()
+    assert backend._surface._finalize.atexit is False
+
+
+def test_capture_after_close_raises_instead_of_blitting(make_backend):
+    """Blitting through a deleted DC is undefined, not an error."""
+    backend, _, gdi32 = make_backend()
+    _capture(backend, 0, 0, 8, 8)
+    backend.close()
+
+    before = len(gdi32.blits)
+    with pytest.raises(RuntimeError, match="closed"):
+        _capture(backend, 0, 0, 8, 8)
+    assert len(gdi32.blits) == before, "a closed backend still reached BitBlt"
+
+
+def test_resizing_frees_the_previous_bitmap_but_keeps_the_dc(make_backend):
+    """Pre-existing behaviour the refactor must not disturb."""
+    backend, _, gdi32 = make_backend()
+    _capture(backend, 0, 0, 8, 8)
+    first = backend._surface.bitmap
+    mem_dc = backend._surface.mem_dc
+
+    _capture(backend, 0, 0, 4, 4)
+    second = backend._surface.bitmap
+
+    assert second != first
+    assert first in gdi32.deleted_bitmaps
+    assert second not in gdi32.deleted_bitmaps
+    assert gdi32.deleted_dcs == [], "the memory DC survives a resize"
+    assert backend._surface.mem_dc == mem_dc
+
+
+def test_closing_one_backend_leaves_another_untouched(make_backend):
+    """Each instance owns its own DC; close() must not reach past it.
+
+    Every make_backend() call installs a fresh pair of fakes, so the two
+    backends are asserted against their own gdi32 rather than compared
+    by handle value.
+    """
+    first, _, gdi_first = make_backend()
+    second, _, gdi_second = make_backend()
+    _capture(first, 0, 0, 8, 8)
+    _capture(second, 0, 0, 8, 8)
+    # Read before closing: teardown nulls the handles it has freed.
+    first_dc = first._surface.mem_dc
+
+    first.close()
+
+    assert gdi_first.deleted_dcs == [first_dc]
+    assert gdi_second.deleted_dcs == [], "closing one backend freed another's DC"
+    assert gdi_second.deleted_bitmaps == []
+    assert _capture(second, 0, 0, 8, 8).shape == (8, 8, 4)

--- a/tests/test_wlr_backend.py
+++ b/tests/test_wlr_backend.py
@@ -8,6 +8,9 @@ transform refusal exist for are unreachable there. The scale-2 mapping
 for the one scale ``wlr-randr`` is asked to set. These drive the same
 code over hand-built output state instead.
 """
+import gc
+import mmap
+import os
 from types import SimpleNamespace
 
 import numpy
@@ -18,7 +21,7 @@ pytest.importorskip(
 )
 
 from fastgrab.backends.wlr import (  # noqa: E402
-    WlrBackend, _plan_region, _uniform_integer_scale,
+    WlrBackend, _ShmBuffer, _plan_region, _release_shm, _uniform_integer_scale,
 )
 
 # Hand-built output state only — no compositor, no display server.
@@ -610,3 +613,141 @@ def test_the_pre_v3_refusal_explains_buffer_done(monkeypatch):
         _connect_against(
             [("zwlr_screencopy_manager_v1", 1), ("wl_shm", 1)], monkeypatch
         )
+
+
+# -------- _ShmBuffer: freeing a frame buffer --------
+#
+# Nothing ever freed the per-instance SHM buffer, so each Screenshot
+# leaked a memfd and a frame's worth of memory. The descriptor half is
+# measured against a real compositor in tests/test_integration_wlr.py.
+# The memory half is asserted here, because it is not ours to free: the
+# compositor holds its own mapping of the memfd for as long as it owns
+# the wl_buffer. Measured on cage, 50 dropped buffers held 175.5 MiB of
+# system Shmem and closing every descriptor by hand released *none* of
+# it; the destroy() requests took the same 50 down to 0.8 MiB. So the
+# call that matters is destroy(), and these pin it down without reading
+# a system-wide counter that CI cannot hold still.
+
+
+class _FakeWlBuffer:
+    """A wl_buffer proxy that records whether it was destroyed."""
+
+    def __init__(self, fail=False):
+        self.destroys = 0
+        self._fail = fail
+
+    def destroy(self):
+        self.destroys += 1
+        if self._fail:
+            raise RuntimeError("connection is gone")
+
+
+def _shm_buffer(**kw):
+    """A real memfd + mmap, so close()/fd handling is not itself faked."""
+    fd = os.memfd_create("fastgrab-wlr-test", 0)
+    os.ftruncate(fd, 4096)
+    mm = mmap.mmap(fd, 4096, prot=mmap.PROT_READ | mmap.PROT_WRITE,
+                   flags=mmap.MAP_SHARED)
+    wl = _FakeWlBuffer(**kw)
+    return _ShmBuffer(mm, fd, wl, 32, 32, 128, 0), mm, fd, wl
+
+
+def _fd_is_open(fd):
+    try:
+        os.fstat(fd)
+    except OSError:
+        return False
+    return True
+
+
+def test_closing_a_buffer_destroys_the_wl_buffer():
+    """The one call that gets the memory back from the compositor."""
+    buf, mm, fd, wl = _shm_buffer()
+    buf.close()
+    assert wl.destroys == 1
+    assert mm.closed
+    assert not _fd_is_open(fd)
+
+
+def test_dropping_a_buffer_destroys_the_wl_buffer():
+    """No close() anywhere — collection alone must free it.
+
+    This is what removes the leak: WlrBackend has no __del__ and must not
+    grow one, so the buffer has to free itself when the backend that
+    owned it goes away.
+    """
+    buf, mm, fd, wl = _shm_buffer()
+    del buf
+    gc.collect()
+    assert wl.destroys == 1
+    assert mm.closed
+    assert not _fd_is_open(fd)
+
+
+def test_closing_a_buffer_twice_destroys_once():
+    buf, _, _, wl = _shm_buffer()
+    buf.close()
+    buf.close()
+    assert wl.destroys == 1
+
+
+def test_an_explicitly_closed_buffer_is_not_freed_again_on_collection():
+    buf, _, fd, wl = _shm_buffer()
+    buf.close()
+    del buf
+    gc.collect()
+    assert wl.destroys == 1
+    assert not _fd_is_open(fd)
+
+
+def test_the_finalizer_does_not_run_at_interpreter_exit():
+    """Deliberate. Firing at shutdown is what makes __del__ unsafe here.
+
+    destroy() is a request on the display connection, and at shutdown
+    that connection may already be half torn down — the segfault the
+    backend's "intentionally no __del__" note is about. The kernel
+    reclaims the fd and the mapping then anyway, and the compositor
+    drops everything when the socket closes, so there is nothing to win.
+    """
+    buf, _, _, _ = _shm_buffer()
+    assert buf._finalize.atexit is False
+    buf.close()
+
+
+def test_a_dead_connection_does_not_raise_out_of_teardown():
+    """destroy() on a lost connection is not a leak, and must not throw.
+
+    _release_shm runs from a finalizer, where an exception surfaces at an
+    arbitrary point in someone else's stack. The compositor frees every
+    resource it held for us when the socket closes.
+    """
+    buf, mm, fd, wl = _shm_buffer(fail=True)
+    buf.close()  # must not raise
+    assert wl.destroys == 1
+    # And our own handles still came back despite the failure above.
+    assert mm.closed
+    assert not _fd_is_open(fd)
+
+
+def test_release_frees_our_handles_even_if_destroy_raises():
+    """_release_shm directly, since the ordering is the whole point."""
+    fd = os.memfd_create("fastgrab-wlr-test", 0)
+    os.ftruncate(fd, 4096)
+    mm = mmap.mmap(fd, 4096, prot=mmap.PROT_READ | mmap.PROT_WRITE,
+                   flags=mmap.MAP_SHARED)
+    wl = _FakeWlBuffer(fail=True)
+    _release_shm(mm, fd, wl)
+    assert wl.destroys == 1
+    assert mm.closed
+    assert not _fd_is_open(fd)
+
+
+def test_matches_distinguishes_every_dimension():
+    """_ensure_buffer reuses on this; a loose compare would reuse wrongly."""
+    buf, _, _, _ = _shm_buffer()
+    assert buf.matches(32, 32, 128, 0)
+    assert not buf.matches(33, 32, 128, 0)
+    assert not buf.matches(32, 33, 128, 0)
+    assert not buf.matches(32, 32, 129, 0)
+    assert not buf.matches(32, 32, 128, 1)
+    buf.close()


### PR DESCRIPTION
Every `Screenshot` built a backend that allocated an OS-level frame buffer, and
nothing ever released it. Both backends said so themselves — wlr's
*"Intentionally no `__del__`"* and windows' *"No `__del__`: matching the wlr
backend, we let the OS reclaim ... at process exit"*. Avoiding `__del__` was the
right call; leaving nothing in its place was not.

It hits the shape this library advertises hardest, because that form throws the
object away by construction:

```python
img = screenshot.Screenshot().capture()
```

## Measured, against cage

One memfd per instance, surviving `del` + `gc.collect()`:

```
after   1 more instances: total fds=  6  fastgrab-wlr memfds=  1
after  50 more instances: total fds= 81  fastgrab-wlr memfds= 76
```

With `RLIMIT_NOFILE` lowered to 64 to make it quick: **iteration 43 →
`OSError: [Errno 24] Too many open files`.** After the fix the same probe runs
199 iterations with `memfds=0` and the total fd count flat at 5.

## The memory is the worse half, and it is not ours to free

RSS stays flat, because CPython's mmap deallocator unmaps on GC. The memory is
held by the **compositor**, which keeps its own mapping of the memfd for as long
as it owns the `wl_buffer`:

```
+75 dropped instances:                system Shmem + 263.4 MiB
after closing the leaked fds by hand: system Shmem + 263.4 MiB   <-- freed nothing
```

The call that actually releases it is `wl_buffer.destroy()`:

```
50 live instances:                    Shmem + 175.5 MiB
after wl_buffer.destroy() + close:    Shmem +   0.8 MiB
```

On Windows the equivalent pair is a memory DC plus a DIBSection whose pixels
leak with the handle — ~8 MB per instance at 1080p, so `CreateDIBSection` fails
on memory thousands of instances before GDI's 10,000-handle quota is reached.

## The fix

Each backend's handles move into a small owner object carrying a
`weakref.finalize`, so dropping the backend frees them without giving the
backend a `__del__`. That separation is the point: the finalizer's subject is
the handle holder, not the pywayland-entangled backend whose shutdown-order
finalisation is the actual hazard.

`atexit` is off on both. The kernel reclaims everything at exit and the
compositor drops its resources when the socket closes, so firing then buys
nothing and would push a request through a half-torn-down display — the segfault
the old note warned about.

`Screenshot` grows `close()` and context-manager support for callers who want a
deterministic moment rather than GC timing. `capture()` is unchanged and refuses
to run on a closed instance, because `BitBlt` through a deleted DC is undefined
rather than an error.

## Two defects the new tests caught in the fix itself

- `_ShmBuffer.__slots__` omitted `__weakref__`, so `weakref.finalize` could not
  attach — the wlr half was inert until the unit test failed on it.
- One buffer is **two** descriptors, not one: `mmap.mmap()` dups internally. The
  original leak measured as one per instance because GC reclaimed the mmap's dup
  while the raw memfd stayed open.

## Verification

`docker compose run --rm test` → **328 passed** (was 305).
`docker compose run --rm test-wayland` → **29 passed** (was 23).

Controls, run against the committed fix, neutering *only* the automatic release
so explicit `close()` still works:

- X11 suite → **3 failed**: `test_dropping_the_backend_frees_its_gdi_handles`,
  `test_many_dropped_backends_leak_no_handles`,
  `test_dropping_a_buffer_destroys_the_wl_buffer`.
- Wayland suite → **2 failed**: `test_dropped_screenshot_objects_do_not_leak`,
  `test_the_two_line_api_in_a_loop_does_not_leak`, with real growth 39 → 69 fds
  over 30 iterations.

Every explicit-`close()` test still passed under the control, which is what
isolates the failures to the drop path.
