### PR TITLE
x11: refuse a 32-bit image whose channels are not BGRA

### DIFF
--- a/fastgrab/linux_x11/screenshot.c
+++ b/fastgrab/linux_x11/screenshot.c
@@ -35,6 +35,27 @@
 #define FG_ERR_LOST     -8
 #define FG_ERR_NOMEM    -9
 #define FG_ERR_XPROTO  -10
+#define FG_ERR_FORMAT  -11
+
+/* The only 32-bit ZPixmap layout whose bytes are already B,G,R,A on a
+ * little-endian host -- what the Python side promises callers. These are
+ * the masks a depth-24 visual reports; every channel sits on a byte
+ * boundary, so the server's rows can be memcpy'd out untouched. */
+#define FG_BGRA_RED_MASK   0x00ff0000UL
+#define FG_BGRA_GREEN_MASK 0x0000ff00UL
+#define FG_BGRA_BLUE_MASK  0x000000ffUL
+
+/* Detail for FG_ERR_FORMAT, filled in on the refusal path so fg_raise can
+ * name what the server actually offered. Same reasoning as the
+ * fg_xerr_* statics: the GIL is held for the whole call, and a message
+ * that does not say which layout was rejected sends the reader back to
+ * xdpyinfo to find out. */
+static unsigned long fg_fmt_red = 0;
+static unsigned long fg_fmt_green = 0;
+static unsigned long fg_fmt_blue = 0;
+static int fg_fmt_depth = 0;
+static int fg_fmt_byte_order = 0;
+
 
 static const char *fg_strerror(int code)
 {
@@ -63,6 +84,9 @@ static const char *fg_strerror(int code)
                "was dropped, so a later call will reconnect";
     case FG_ERR_XPROTO:
         return "the X server rejected the request with a protocol error";
+    case FG_ERR_FORMAT:
+        return "the X server returned a 32-bit image whose channels are "
+               "not byte-aligned BGRA";
     default:
         return "unknown X11 error";
     }
@@ -592,6 +616,28 @@ static int fg_op_screenshot(Display *dpy, void *ctx)
         return FG_ERR_DEPTH;
     }
 
+    /* bits_per_pixel says how *wide* a pixel is, not how its channels are
+     * arranged inside that width. A depth-30 visual -- 10:10:10 packed
+     * RGB, which amdgpu and nvidia ship for 10-bit output and Xvfb will
+     * happily serve -- is also 32 bits per pixel, so the check above let
+     * it through and the packed value was handed back as if it were
+     * BGRA. Measured on Xvfb at depth 30: a mid grey (512,512,512) came
+     * back B=0 G=2 R=8 A=32, near black, and a mid orange lost its green
+     * channel entirely. Saturated primaries survived close enough to
+     * look right, which is how this stayed invisible. */
+    if (img->red_mask != FG_BGRA_RED_MASK ||
+        img->green_mask != FG_BGRA_GREEN_MASK ||
+        img->blue_mask != FG_BGRA_BLUE_MASK ||
+        img->byte_order != LSBFirst) {
+        fg_fmt_red = img->red_mask;
+        fg_fmt_green = img->green_mask;
+        fg_fmt_blue = img->blue_mask;
+        fg_fmt_depth = img->depth;
+        fg_fmt_byte_order = img->byte_order;
+        XDestroyImage(img);
+        return FG_ERR_FORMAT;
+    }
+
     const size_t row_bytes = (size_t)req->width * 4;
     const size_t nbytes = row_bytes * (size_t)req->height;
 
@@ -715,6 +761,29 @@ static PyObject *fg_raise(int rc)
                      "have been resized between the bounds check and the "
                      "capture.",
                      (unsigned)fg_xerr_code, (unsigned)fg_xerr_request);
+        return NULL;
+    }
+    if (rc == FG_ERR_FORMAT) {
+        /* snprintf, not PyErr_Format: PyUnicode_FromFormat understands
+         * only a subset of printf and silently copies the rest of the
+         * string verbatim when it meets something it does not know --
+         * "%08lx" among them, which printed the format specifiers
+         * themselves into the message. */
+        char detail[768];
+        snprintf(detail, sizeof(detail),
+                 "the X server returned a %d-bit-deep image whose channels "
+                 "are not byte-aligned BGRA: masks R=0x%08lx G=0x%08lx "
+                 "B=0x%08lx, byte order %s. fastgrab copies the server's "
+                 "rows out verbatim, so it can only promise BGRA for the "
+                 "depth-24 layout (R=0x%08lx G=0x%08lx B=0x%08lx, "
+                 "LSBFirst). A depth-30 screen packs 10:10:10 RGB into the "
+                 "same 32 bits, which is not byte-aligned channels at all "
+                 "-- read as BGRA, a mid grey comes back near black. Run "
+                 "the X server at depth 24.",
+                 fg_fmt_depth, fg_fmt_red, fg_fmt_green, fg_fmt_blue,
+                 fg_fmt_byte_order == LSBFirst ? "LSBFirst" : "MSBFirst",
+                 FG_BGRA_RED_MASK, FG_BGRA_GREEN_MASK, FG_BGRA_BLUE_MASK);
+        PyErr_SetString(PyExc_RuntimeError, detail);
         return NULL;
     }
     PyErr_SetString(PyExc_RuntimeError, fg_strerror(rc));

--- a/tests/test_x11_lowlevel.py
+++ b/tests/test_x11_lowlevel.py
@@ -512,9 +512,9 @@ def socket_path(display):
     return "/tmp/.X11-unix/X" + display.lstrip(":").split(".")[0]
 
 
-def start(display):
+def start(display, depth=24):
     proc = subprocess.Popen(
-        ["Xvfb", display, "-screen", "0", "320x240x24", "-ac"],
+        ["Xvfb", display, "-screen", "0", "320x240x%d" % depth, "-ac"],
         stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
     )
     _servers.append(proc)
@@ -993,3 +993,75 @@ def test_a_rejected_request_names_the_x_error():
         _linux_x11._force_x_protocol_error()
     # And the cached connection survives it, in process too.
     assert _linux_x11.resolution() == _linux_x11.resolution()
+
+
+# -------- pixel layout --------
+
+_PIXEL_FORMAT_TEMPLATE = r'''
+import numpy
+
+display = sys.argv[1]
+start(display, depth=__DEPTH__)
+if not wait_for_socket(display):
+    finish(4, "NO-SOCKET")
+if wait_for_extension(display) is None:
+    finish(4, "NO-EXTENSION")
+
+img = numpy.zeros((8, 8, 4), "uint8")
+try:
+    _linux_x11.screenshot(0, 0, img)
+except RuntimeError as exc:
+    say("REFUSED " + " ".join(str(exc).split()))
+    finish(0)
+say("CAPTURED")
+finish(0)
+'''
+
+
+def _pixel_format_script(depth):
+    return _XVFB_PRELUDE + _PIXEL_FORMAT_TEMPLATE.replace("__DEPTH__", str(depth))
+
+
+def test_a_depth_30_screen_is_refused_rather_than_copied_out_as_bgra():
+    """bits_per_pixel says how wide a pixel is, not how it is arranged.
+
+    A depth-30 visual packs 10:10:10 RGB into 32 bits, so it passed the
+    only check there was and the packed value was handed back as if its
+    bytes were B, G, R, A. Nothing failed and nothing warned; the caller
+    got wrong colours. Measured on this same Xvfb before the fix, a mid
+    grey painted as (512, 512, 512) came back as B=0 G=2 R=8 A=32 — near
+    black — and a mid orange lost its green channel outright. Saturated
+    primaries came back close enough to look correct, which is exactly
+    why it could go unnoticed.
+    """
+    result, report = _run_x_fault_script(_pixel_format_script(30))
+    assert result.returncode == 0, report
+    assert "REFUSED" in result.stdout, report
+    assert "CAPTURED" not in result.stdout, report
+
+
+def test_the_refusal_names_the_layout_the_server_offered():
+    """Without the masks the message cannot be acted on.
+
+    "not BGRA" sends the reader to xdpyinfo to find out what they have;
+    the masks and the depth say it outright, and naming the layout
+    fastgrab *does* accept says what to change.
+    """
+    result, report = _run_x_fault_script(_pixel_format_script(30))
+    assert result.returncode == 0, report
+    # what the server offered
+    assert "30-bit-deep" in result.stdout, report
+    assert "R=0x3ff00000" in result.stdout, report
+    assert "G=0x000ffc00" in result.stdout, report
+    assert "B=0x000003ff" in result.stdout, report
+    assert "LSBFirst" in result.stdout, report
+    # and what it would have had to be
+    assert "R=0x00ff0000" in result.stdout, report
+
+
+def test_a_depth_24_screen_still_captures():
+    """The control: the same script one depth down must not be refused."""
+    result, report = _run_x_fault_script(_pixel_format_script(24))
+    assert result.returncode == 0, report
+    assert "CAPTURED" in result.stdout, report
+    assert "REFUSED" not in result.stdout, report


### PR DESCRIPTION
The capture path checked `bits_per_pixel != 32` and nothing else. That says how
*wide* a pixel is, not how its channels are arranged inside that width.

A depth-30 visual — 10:10:10 packed RGB, which amdgpu and nvidia ship for 10-bit
output and which Xvfb serves happily — is **also** 32 bits per pixel. So it
passed, and the packed value was `memcpy`'d out and handed back as if its bytes
were B, G, R, A. Nothing failed and nothing warned.

## Measured

Painted via `XFillRectangle` on Xvfb and read back through `capture()`:

| painted | depth 24 (correct) | depth 30 (before this fix) |
|---|---|---|
| red `(max,0,0)` | B=0 G=0 R=255 | B=0 G=0 **R=240** A=63 |
| green `(0,max,0)` | B=0 G=255 R=0 | B=0 **G=252 R=15** |
| blue `(0,0,max)` | B=255 G=0 R=0 | **B=255 G=3** R=0 |
| grey `(mid,mid,mid)` | B=128 G=128 R=128 | **B=0 G=2 R=8 A=32** |
| orange `(max,mid,0)` | B=0 G=128 R=255 | B=0 **G=0** R=248 A=63 |

Saturated primaries survive close enough to look right — which is how this
stayed invisible. Mid grey collapses to **near black**, mid orange loses its
green channel outright, and alpha fills with the top bits of red.

The channels aren't byte-aligned at depth 30: blue is bits 0–9, green 10–19, red
20–29, so byte 1 is *two bits of blue plus six of green*. There is no
interpretation under which the copied bytes are BGRA.

## The fix

The capture path now also requires the depth-24 masks (`R=0x00ff0000`,
`G=0x0000ff00`, `B=0x000000ff`) and `LSBFirst` byte order, and refuses anything
else:

```
RuntimeError: the X server returned a 30-bit-deep image whose channels are not
byte-aligned BGRA: masks R=0x3ff00000 G=0x000ffc00 B=0x000003ff, byte order
LSBFirst. fastgrab copies the server's rows out verbatim, so it can only promise
BGRA for the depth-24 layout (R=0x00ff0000 G=0x0000ff00 B=0x000000ff, LSBFirst).
A depth-30 screen packs 10:10:10 RGB into the same 32 bits, which is not
byte-aligned channels at all -- read as BGRA, a mid grey comes back near black.
Run the X server at depth 24.
```

**Refusing rather than converting** is deliberate. Unpacking 10-bit to 8-bit is
lossy, and choosing to do it silently is a product decision rather than a bug
fix — it would surprise anyone running a 10-bit screen on purpose. Unlike the
wlr ABGR case, this one *is* testable (Xvfb serves depth 30), so adding
conversion later is a real option; it just shouldn't ride along in a
correctness fix.

One implementation note: the message is built with `snprintf`, not
`PyErr_Format`. `PyUnicode_FromFormat` understands only a subset of printf and
copies the rest of the string verbatim when it hits something it doesn't know —
`%08lx` among them, which printed the format specifiers into the error. Caught
by the test that asserts the masks appear.

## Verification

`docker compose run --rm test` → **331 passed** (was 328).
`docker compose run --rm test-wayland` → **29 passed**.

The Xvfb test prelude now takes a depth, so the refusal is proved against a real
10:10:10 server, with a depth-24 run of the same script as the control.

Control, against the committed fix — mask check replaced with `if (0)`:

- **2 failed**: `test_a_depth_30_screen_is_refused_rather_than_copied_out_as_bgra`,
  `test_the_refusal_names_the_layout_the_server_offered`.
- `test_a_depth_24_screen_still_captures` **passed** under the control, which is
  what shows the two failures are about the missing check and not about the
  harness.
