### PR TITLE
recording: render drawtext titles as the user typed them

### DIFF
--- a/fastgrab/recording/encoder.py
+++ b/fastgrab/recording/encoder.py
@@ -90,11 +90,12 @@ def infer_codec(path: str) -> str:
 
 
 def _escape_drawtext(text: str) -> str:
-    """Escape user text for ffmpeg's drawtext text= field.
+    """Escape a value for an *unquoted* drawtext option — a path, say.
 
-    ffmpeg's filter parser splits on ``:`` and treats ``\\`` and ``'``
-    specially. We rewrite the four characters that actually break the
-    parse and leave the rest alone.
+    ffmpeg's filter parser splits options on ``:`` and treats ``\\`` and
+    ``'`` specially, so those are backslash-escaped here. Use
+    :func:`_quote_drawtext_text` for anything going into ``text=``, which
+    is quoted and follows different rules.
     """
     out = []
     for ch in text:
@@ -103,6 +104,48 @@ def _escape_drawtext(text: str) -> str:
         else:
             out.append(ch)
     return "".join(out)
+
+
+def _quote_drawtext_text(text: str) -> str:
+    """Render ``text`` as a complete, quoted drawtext ``text=`` value.
+
+    An apostrophe cannot simply be backslash-escaped here. A filter
+    option inside a filtergraph is unescaped *twice* — once when the
+    graph is split into filters, once when a filter's arguments are
+    split — and a single-quoted section has no escape mechanism at all;
+    it ends at the next quote. ``\\'`` therefore does not survive: it is
+    consumed on the way in and the apostrophe is silently dropped, so
+    ``--title "Don't stop"`` rendered "Dont stop", and with the trailing
+    ``enable=`` option present the stray quote ran the parse off the end
+    and ffmpeg rejected the whole filtergraph with "Filter not found" —
+    no recording at all.
+
+    What works is to close the quote, emit the apostrophe escaped for
+    both levels, and reopen: ``'\\\''``. That was not deduced from the
+    documentation but measured — every candidate was rendered and
+    compared pixel-for-pixel against the same text supplied through
+    ``textfile=``, which takes its content verbatim and so is ground
+    truth. Of the encodings tried it is the only one that reproduces the
+    reference.
+
+    The single backslash used for ``:``, ``\\`` and ``%`` was checked the
+    same way and does reproduce the reference, so it stays. Commas,
+    brackets and semicolons need nothing: the surrounding quotes already
+    protect them from the filtergraph splitter.
+    """
+    # Spelled out rather than written as one literal: the
+    # sequence is quote, three backslashes, quote, quote, and a
+    # nested escape of that is very easy to miscount.
+    apostrophe = "'" + "\\" * 3 + "''"
+    out = []
+    for ch in text:
+        if ch == "'":
+            out.append(apostrophe)
+        elif ch in ("\\", ":", "%"):
+            out.append("\\" + ch)
+        else:
+            out.append(ch)
+    return "'" + "".join(out) + "'"
 
 
 def _build_drawtext_filter(title: str = None, overlay_text: str = None,
@@ -127,24 +170,24 @@ def _build_drawtext_filter(title: str = None, overlay_text: str = None,
     parts = []
     if title:
         parts.append(
-            "drawtext=fontfile={font}:text='{text}':"
+            "drawtext=fontfile={font}:text={text}:expansion=none:"
             "fontcolor=white:fontsize=40:"
             "box=1:boxcolor=black@0.55:boxborderw=12:"
             "x=(w-text_w)/2:y=30:"
             "enable='lt(t,{secs})'".format(
                 font=font,
-                text=_escape_drawtext(title),
+                text=_quote_drawtext_text(title),
                 secs=title_seconds,
             )
         )
     if overlay_text:
         parts.append(
-            "drawtext=fontfile={font}:text='{text}':"
+            "drawtext=fontfile={font}:text={text}:expansion=none:"
             "fontcolor=white@0.85:fontsize=22:"
             "box=1:boxcolor=black@0.4:boxborderw=6:"
             "x=w-text_w-20:y=20".format(
                 font=font,
-                text=_escape_drawtext(overlay_text),
+                text=_quote_drawtext_text(overlay_text),
             )
         )
     return ",".join(parts)

--- a/fastgrab/recording/subtitles.py
+++ b/fastgrab/recording/subtitles.py
@@ -14,7 +14,11 @@ drawtext expressiveness without any parsing on our side.
 """
 from dataclasses import dataclass
 
-from .encoder import _escape_drawtext, _find_font
+from .encoder import (
+    _escape_drawtext,
+    _find_font,
+    _quote_drawtext_text,
+)
 
 
 @dataclass
@@ -84,12 +88,12 @@ def build_subtitle_filters(subtitles, style=None) -> "str | None":
     parts = []
     for sub in subtitles:
         parts.append(
-            "drawtext=fontfile={font}:text='{text}':"
+            "drawtext=fontfile={font}:text={text}:expansion=none:"
             "fontcolor={color}:fontsize={size}:"
             "box=1:boxcolor={box}:boxborderw={border}:"
             "{xy}:enable='between(t,{start},{end})'".format(
                 font=font,
-                text=_escape_drawtext(sub.text),
+                text=_quote_drawtext_text(sub.text),
                 color=style.font_color,
                 size=style.font_size,
                 box=style.box_color,

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -716,3 +716,156 @@ def test_the_drain_is_quiet_before_the_encoder_starts(tmp_path):
     """No file yet is not an error — write_frame() can be reached first."""
     enc = FfmpegEncoder(str(tmp_path / "out.mp4"), 64, 48, fps=30)
     assert enc._drain_stderr() == ""
+
+
+# -------- drawtext: text the user typed must be the text on screen --------
+#
+# Two bugs lived here, and both were invisible in a filter-string
+# assertion — you have to render to see them.
+#
+# An apostrophe cannot be backslash-escaped in a drawtext text= value. A
+# filter option inside a filtergraph is unescaped twice (once splitting
+# the graph, once splitting a filter's arguments) and a single-quoted
+# section has no escape mechanism at all. \' was consumed on the way in,
+# so --title "Don't stop" rendered "Dont stop"; with the trailing
+# enable= option present the stray quote ran the parse off the end and
+# ffmpeg rejected the whole filtergraph with "Filter not found" — no
+# recording at all.
+#
+# And with drawtext's default expansion=normal, a literal % blanks the
+# *entire* text. No escaping helps: '100\% done', '100%% done' and a
+# verbatim textfile= all render nothing. Only expansion=none renders it,
+# which also stops the text being reinterpreted as %{...} directives.
+
+_DRAWTEXT_CASES = [
+    "Release demo",
+    "Don't stop",
+    "100% done",
+    "step 1: begin",
+    "C:\\path\\to",
+    "%{pts}",
+    "don't: 50%",
+    "it's a 'quote'",
+    "a,b[c]d;e",
+    "trailing'",
+    "'leading",
+    "''",
+    "50% — done",
+]
+
+
+def _render_gray(vf, width=900, height=120):
+    """One frame through `vf` over black, as a gray numpy array."""
+    proc = subprocess.run(
+        ["ffmpeg", "-v", "error", "-f", "lavfi",
+         "-i", "color=black:s=%dx%d:d=0.1" % (width, height),
+         "-vf", vf, "-frames:v", "1", "-f", "rawvideo", "-pix_fmt", "gray", "-"],
+        capture_output=True,
+    )
+    if proc.returncode != 0:
+        return None, proc.stderr.decode("utf-8", "replace").strip()
+    return numpy.frombuffer(proc.stdout, dtype=numpy.uint8).reshape(height, width), ""
+
+
+def _reference_vf(text, path, font):
+    """The same drawtext, with the text supplied through textfile=.
+
+    textfile= takes its content verbatim — no escaping layer at all — so
+    this is ground truth for what the user's string should look like.
+    """
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(text)
+    return (
+        "drawtext=fontfile={font}:textfile={tf}:expansion=none:"
+        "fontcolor=white:fontsize=40:"
+        "box=1:boxcolor=black@0.55:boxborderw=12:x=(w-text_w)/2:y=30:"
+        "enable='lt(t,3.0)'".format(
+            font=encoder_mod._escape_drawtext(font),
+            tf=encoder_mod._escape_drawtext(path),
+        )
+    )
+
+
+@requires_ffmpeg
+@pytest.mark.parametrize("title", _DRAWTEXT_CASES)
+def test_a_title_renders_exactly_as_typed(title, tmp_path):
+    font = encoder_mod._find_font()
+    if font is None:
+        pytest.skip("no usable font on this host")
+
+    ours, our_err = _render_gray(encoder_mod._build_drawtext_filter(title=title))
+    assert ours is not None, "ffmpeg rejected the filter for {!r}: {}".format(
+        title, our_err
+    )
+
+    want, ref_err = _render_gray(
+        _reference_vf(title, str(tmp_path / "ref.txt"), font)
+    )
+    assert want is not None, "the reference render failed: " + ref_err
+
+    # Blank-vs-blank would compare equal and prove nothing — that is how
+    # the percent bug hid behind the apostrophe one.
+    assert (want > 40).sum() > 0, "the reference rendered nothing for {!r}".format(title)
+    assert numpy.array_equal(ours, want), (
+        "{!r} does not render as typed: {} lit pixels vs {} in the reference"
+        .format(title, int((ours > 40).sum()), int((want > 40).sum()))
+    )
+
+
+def test_an_apostrophe_is_closed_escaped_and_reopened():
+    """The only encoding that survives both unescaping passes."""
+    quoted = encoder_mod._quote_drawtext_text("Don't")
+    assert quoted == "'Don'" + "\\" * 3 + "''t'"
+    # and the plain backslash-escape that used to be emitted is not it
+    assert "\\'t" not in quoted.replace("\\" * 3 + "'", "")
+
+
+def test_the_other_specials_keep_their_single_backslash():
+    q = encoder_mod._quote_drawtext_text
+    assert q("a:b") == "'a\\:b'"
+    assert q("100%") == "'100\\%'"
+    assert q("a\\b") == "'a\\\\b'"
+    # commas and brackets need nothing — the quotes already cover them
+    assert q("a,b[c]") == "'a,b[c]'"
+
+
+def test_every_drawtext_filter_disables_expansion(tmp_path):
+    """A % anywhere in the text blanks the whole render without this.
+
+    The font is passed explicitly: both builders return None when they
+    cannot find one, and a runner without DejaVu installed would turn
+    this assertion into an AttributeError rather than a useful failure.
+    """
+    font = tmp_path / "fake.ttf"
+    font.write_bytes(b"")
+    vf = encoder_mod._build_drawtext_filter(
+        title="t", overlay_text="o", font_path=str(font)
+    )
+    assert vf.count("expansion=none") == 2, vf
+    chain = subtitles_mod.build_subtitle_filters(
+        [Subtitle(text="hello", start=0.0, end=1.0)],
+        SubtitleStyle(font_path=str(font)),
+    )
+    assert "expansion=none" in chain, chain
+
+
+@requires_ffmpeg
+def test_a_subtitle_renders_its_apostrophe(tmp_path):
+    """subtitles.py builds its own drawtext chain and shared the bug."""
+    font = encoder_mod._find_font()
+    if font is None:
+        pytest.skip("no usable font on this host")
+    style = SubtitleStyle(font_path=font)
+    chain = subtitles_mod.build_subtitle_filters(
+        [Subtitle(text="don't stop", start=0.0, end=5.0)], style
+    )
+    got, err = _render_gray(chain)
+    assert got is not None, "ffmpeg rejected the subtitle chain: " + err
+    plain = subtitles_mod.build_subtitle_filters(
+        [Subtitle(text="dont stop", start=0.0, end=5.0)], style
+    )
+    bare, _ = _render_gray(plain)
+    assert bare is not None
+    # The apostrophe has to actually be drawn — dropping it silently was
+    # the original symptom, and that renders the same as "dont stop".
+    assert not numpy.array_equal(got, bare), "the apostrophe was dropped"


### PR DESCRIPTION
Two bugs in the same place, both invisible to a filter-string assertion. Both
were found by **rendering** each case and comparing pixel-for-pixel against the
same text supplied through drawtext's `textfile=`, which takes its content
verbatim and so is ground truth.

## 1. An apostrophe cannot be backslash-escaped

A filter option inside a filtergraph is unescaped **twice** — once splitting the
graph into filters, once splitting a filter's arguments — and a single-quoted
section has no escape mechanism at all; it ends at the next quote. So `\'` was
consumed on the way in.

```
--title "Don't stop"   ->  rendered "Dont stop"     (apostrophe silently dropped)
```

Worse, because a trailing `enable=` option follows the text, the stray quote ran
the parse off the end and ffmpeg rejected the whole filtergraph with
**"Filter not found"** — no recording at all.

Measured across every candidate encoding, exactly one reproduces the reference:

| encoding | quoted context | unquoted |
|---|---|---|
| `\'` | apostrophe dropped | blank |
| `'\''` | blank | dropped |
| `''` | dropped | dropped |
| **`'\\\''`** | **matches** | dropped |
| `\\\'` | dropped | **matches** |

The single backslash used for `:`, `\` and `%` was checked the same way and does
reproduce the reference, so it stays. Commas, brackets and semicolons need
nothing — the surrounding quotes already cover them.

## 2. A literal `%` blanks the entire title

With drawtext's default `expansion=normal`, nothing escapes out of it:

```
text='100\% done'    -> 0 lit pixels
text='100%% done'    -> 0 lit pixels
textfile= (verbatim) -> 0 lit pixels
                     ... with expansion=none -> renders correctly
```

So `--title "100% done"` produced **no title at all**, silently. Only
`expansion=none` renders it — which also stops a user's text being reinterpreted
as `%{...}` directives.

The cost: `%{...}` no longer expands in a title, overlay or subtitle. That was
never documented, and a percent sign in a title is far commoner than someone
relying on it.

`subtitles.py` builds its own drawtext chain and shared both bugs.

## The trap this kept falling into

Blank matching blank compares equal. The percent bug hid behind the apostrophe
one through **two** rounds of checking — my first pass reported `100% done` as
"ok" because both sides rendered nothing. The tests now assert the reference is
non-blank before comparing.

I also introduced and then caught a defect of my own: a line-based patch put the
apostrophe constant into `_escape_drawtext` as well, and the first control
silently replaced *that* copy — reporting a clean pass while the real code was
untouched. Removed, and the control re-run against the single definition.

## Verification

`docker compose run --rm test` → **356 passed** (was 339).
`docker compose run --rm test-wayland` → **29 passed**.

Controls, each against the committed fix:

- apostrophe encoding reverted to `\'` → **8 failed**, every one an
  apostrophe case, including the subtitle chain.
- `expansion=none` removed → **6 failed**, every one a `%` case (plus the
  filter-shape assertion).
