### PR TITLE
recording: stop the CLI claiming a file it never wrote

### DIFF
--- a/fastgrab/recording/cli.py
+++ b/fastgrab/recording/cli.py
@@ -1,6 +1,7 @@
 """``fastgrab-record`` CLI — argparse around :class:`Recorder`."""
 import argparse
 import math
+import os
 import re
 import signal
 import sys
@@ -404,6 +405,33 @@ def main(argv=None):
 
     if stats is None:
         return 0
+
+    if stats.get("written_frames", stats["frames"]) == 0:
+        # Ctrl-C during the countdown stops the recorder before ffmpeg is
+        # ever started, so there is no file. Reporting that as
+        # "wrote <path>: 0 frames" -- which is what the summary below
+        # does -- sent a script off to open something that was never
+        # created, and the failure then surfaced far from its cause.
+        # Cancelling deliberately is not an error, so the exit status
+        # stays 0, matching the selection- and dialog-cancel paths above.
+        print(
+            "fastgrab: cancelled before the first frame; {} was not "
+            "written".format(stats["output"]),
+            file=sys.stderr,
+        )
+        return 0
+
+    if not os.path.exists(stats["output"]):
+        # Frames went to ffmpeg and it exited cleanly, yet nothing is
+        # there. Whatever the cause, saying "wrote" would be a lie of the
+        # same kind, so fail rather than describe a file that is absent.
+        print(
+            "error: {} frames were encoded but {} does not exist".format(
+                stats["frames"], stats["output"]
+            ),
+            file=sys.stderr,
+        )
+        return 1
 
     duplicated = stats.get("written_frames", stats["frames"]) - stats["frames"]
     print(

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -869,3 +869,89 @@ def test_a_subtitle_renders_its_apostrophe(tmp_path):
     # The apostrophe has to actually be drawn — dropping it silently was
     # the original symptom, and that renders the same as "dont stop".
     assert not numpy.array_equal(got, bare), "the apostrophe was dropped"
+
+
+# -------- what the CLI claims it wrote --------
+#
+# Ctrl-C during the countdown stops the recorder before ffmpeg is ever
+# started. The recorder says so — it returns a zero stats dict, and its
+# own comment reads "Cancelled before the first frame ... there's no
+# file" — but the CLI printed the ordinary summary anyway:
+#
+#   $ fastgrab-record --region 0,0,320,240 --countdown 5 -o out.mp4
+#   ^C
+#   wrote out.mp4: 0 frames in 0.00s (0.0 fps achieved)     # exit 0
+#   $ ls out.mp4
+#   ls: cannot access 'out.mp4': No such file or directory
+#
+# Verified end to end by SIGINTing the real CLI under xvfb.
+
+
+class _StubRecorder:
+    """Stands in for Recorder, returning a chosen stats dict."""
+
+    def __init__(self, stats):
+        self._stats = stats
+
+    def record(self, **kwargs):
+        return self._stats
+
+
+def _run_cli_with(monkeypatch, stats, tmp_path, extra=None):
+    monkeypatch.setattr(
+        recording_cli, "Recorder", lambda **kw: _StubRecorder(stats)
+    )
+    argv = ["--region", "0,0,64,48", "-o", str(tmp_path / "out.mp4")]
+    return recording_cli.main(argv + (extra or []))
+
+
+def _stats(output, frames=0, written=0):
+    return {
+        "frames": frames,
+        "written_frames": written,
+        "elapsed_seconds": 0.0 if not frames else 1.0,
+        "achieved_fps": 0.0 if not frames else float(frames),
+        "output": str(output),
+    }
+
+
+def test_a_cancelled_recording_does_not_claim_a_file(monkeypatch, tmp_path, capsys):
+    out = tmp_path / "out.mp4"
+    rc = _run_cli_with(monkeypatch, _stats(out), tmp_path)
+    captured = capsys.readouterr()
+    assert rc == 0, "a deliberate cancel is not an error"
+    assert "wrote" not in captured.out, captured.out
+    assert "cancelled before the first frame" in captured.err
+    assert str(out) in captured.err
+    assert not out.exists()
+
+
+def test_a_recording_that_produced_no_file_is_an_error(monkeypatch, tmp_path, capsys):
+    """Frames encoded, ffmpeg happy, nothing on disk — do not say "wrote"."""
+    out = tmp_path / "out.mp4"
+    rc = _run_cli_with(monkeypatch, _stats(out, frames=10, written=10), tmp_path)
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "wrote" not in captured.out, captured.out
+    assert "does not exist" in captured.err
+
+
+def test_a_real_recording_still_reports_what_it_wrote(monkeypatch, tmp_path, capsys):
+    """The ordinary path must be untouched."""
+    out = tmp_path / "out.mp4"
+    out.write_bytes(b"not really an mp4, but it exists")
+    rc = _run_cli_with(monkeypatch, _stats(out, frames=30, written=30), tmp_path)
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "wrote {}".format(out) in captured.out
+    assert "30 frames" in captured.out
+
+
+def test_duplicated_frames_are_still_reported(monkeypatch, tmp_path, capsys):
+    """written_frames > frames is the slow-capture case, not a cancel."""
+    out = tmp_path / "out.mp4"
+    out.write_bytes(b"x")
+    rc = _run_cli_with(monkeypatch, _stats(out, frames=10, written=25), tmp_path)
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "15 duplicated" in captured.out, captured.out


### PR DESCRIPTION
Ctrl-C during the countdown stops the recorder before ffmpeg is ever started. The
recorder knows this — it returns a zero stats dict, and its own comment reads
*"Cancelled before the first frame ... there's no file"* — but the CLI printed
the ordinary summary anyway:

```
$ fastgrab-record --region 0,0,320,240 --countdown 5 -o out.mp4
^C
wrote out.mp4: 0 frames in 0.00s (0.0 fps achieved)     # exit 0
$ ls out.mp4
ls: cannot access 'out.mp4': No such file or directory
```

A script doing `fastgrab-record … && upload out.mp4` gets a clean exit and a
missing file, and the failure surfaces far from its cause.

## What I actually found

The queued finding was "Ctrl-C reports a clean stop as failure". That is **not**
what happens — the opposite is. I SIGINTed the real CLI under xvfb across every
interrupt path:

| case | before | file |
|---|---|---|
| SIGINT mid-record | `wrote …: 28 frames`, exit 0 | valid 2.8s mp4 |
| SIGINT twice | `wrote …: 28 frames`, exit 0 | valid 2.8s mp4 |
| SIGTERM mid-record | `wrote …: 28 frames`, exit 0 | valid 2.8s mp4 |
| **SIGINT during countdown** | **`wrote …: 0 frames`, exit 0** | **missing** |
| SIGINT at 0.2s | `KeyboardInterrupt` traceback, exit −2 | missing |

So the three ordinary interrupt paths were already correct and needed no change.
Only the countdown case was wrong, and it was wrong in the other direction.

## The fix

The summary is skipped when no frame ever reached ffmpeg, and the cancellation
is reported on stderr instead:

```
fastgrab: cancelled before the first frame; /tmp/t.mp4 was not written
```

Exit status stays **0** — cancelling on purpose is not an error, and that matches
the existing selection-cancel and dialog-cancel paths in the same file.

A second guard covers the general shape of the same mistake: if frames were
encoded and ffmpeg exited cleanly but the output is not on disk, that is an
error rather than something to describe as written.

## Not fixed, deliberately

A SIGINT arriving in the first fraction of a second — before `signal.signal()`
has run — still dies with a bare `KeyboardInterrupt` traceback. Installing the
handler earlier would narrow that window but cannot close it, and it fails
*loudly*, which is the opposite of the bug being fixed here. Flagging it rather
than folding an unrelated change into this PR.

## Verification

`docker compose run --rm test` → **360 passed** (was 356).

End to end, after the fix:

```
SIGINT during countdown   rc=0   file=MISSING
  stderr: fastgrab: cancelled before the first frame; /tmp/t.mp4 was not written
SIGINT mid-record         rc=0   file=2357 bytes  dur=2.80   (unchanged)
```

Control, against the committed fix — both guards removed → **2 failed**:
`test_a_cancelled_recording_does_not_claim_a_file`,
`test_a_recording_that_produced_no_file_is_an_error`. The two tests covering the
ordinary path kept passing, which is what shows the change is confined to the
cancelled case.
