### PR TITLE
recording: keep ffmpeg's own words when close() fails

### DIFF
--- a/fastgrab/recording/encoder.py
+++ b/fastgrab/recording/encoder.py
@@ -255,6 +255,13 @@ def _ffmpeg_args(codec: str, width: int, height: int, fps: int, output: str,
     return common_in + out
 
 
+# Said instead of trailing an empty string off the end of an error. With
+# -loglevel error a clean run writes nothing, so silence is expected and
+# worth stating rather than leaving the reader wondering whether the
+# message was truncated.
+_NO_STDERR = "(ffmpeg wrote nothing to stderr)"
+
+
 class FfmpegEncoder:
     """Spawn ffmpeg, feed it BGRA frames, and finalise on close.
 
@@ -388,13 +395,30 @@ class FfmpegEncoder:
         if self._proc is None:
             return
         try:
-            if self._proc.stdin is not None:
-                self._proc.stdin.close()
-            rc = self._proc.wait(timeout=timeout)
-        except subprocess.TimeoutExpired:
-            self._proc.kill()
-            self._proc.wait()
-            raise RuntimeError("ffmpeg did not exit within {}s".format(timeout))
+            try:
+                if self._proc.stdin is not None:
+                    self._proc.stdin.close()
+            except BrokenPipeError:
+                # ffmpeg has already gone. Letting this out would report
+                # the broken pipe -- a symptom that names nothing -- and
+                # skip the exit status and stderr below, which say why it
+                # went. Fall through and let those do the talking.
+                pass
+            try:
+                rc = self._proc.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+                self._proc.wait()
+                # Drain before the finally closes the file. A hang is the
+                # case where ffmpeg's own words matter most and the one
+                # where they used to be dropped: the message named only
+                # the timeout, while the finally computed the stderr and
+                # then discarded it.
+                raise RuntimeError(
+                    "ffmpeg did not exit within {}s and was killed: {}".format(
+                        timeout, self._drain_stderr() or _NO_STDERR
+                    )
+                )
         finally:
             err = self._drain_stderr()
             self._proc = None
@@ -403,7 +427,7 @@ class FfmpegEncoder:
                 self._stderr_file = None
         if rc != 0:
             raise RuntimeError(
-                "ffmpeg exited with status {}: {}".format(rc, err)
+                "ffmpeg exited with status {}: {}".format(rc, err or _NO_STDERR)
             )
 
     def _drain_stderr(self, limit: int = 64 * 1024) -> str:

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -1135,3 +1135,104 @@ def test_every_written_frame_reached_the_encoder(monkeypatch, tmp_path):
     stats = rec.record(duration=1.0)
     assert len(made) == 1
     assert made[0].frames == stats["written_frames"]
+
+
+# -------- close() must say why ffmpeg stopped --------
+#
+# The timeout path raised "ffmpeg did not exit within 30s" and nothing
+# else. Its finally block computed the stderr and then dropped it on the
+# floor, so the one failure where ffmpeg's own words matter most — it
+# hung, and you cannot ask it anything afterwards because it gets killed
+# — was the one failure that arrived with no words at all.
+
+_HANGING_CHILD = (
+    "import sys, time\n"
+    "sys.stderr.buffer.write(b'WHY-IT-HUNG\\n')\n"
+    "sys.stderr.buffer.flush()\n"
+    "while True:\n"
+    "    time.sleep(0.05)\n"
+)
+
+_SILENT_HANGING_CHILD = (
+    "import sys, time\n"
+    "while True:\n"
+    "    time.sleep(0.05)\n"
+)
+
+_DYING_CHILD = (
+    "import sys\n"
+    "sys.stderr.buffer.write(b'DIED-BECAUSE-OF-THIS\\n')\n"
+    "sys.stderr.buffer.flush()\n"
+    "sys.exit(3)\n"
+)
+
+
+def _encoder_running(tmp_path, source):
+    enc = FfmpegEncoder(str(tmp_path / "out.mp4"), 64, 48, fps=30)
+    enc._build_argv = lambda: [sys.executable, "-c", source]
+    enc.start()
+    return enc
+
+
+@requires_ffmpeg
+def test_a_hung_encoder_reports_what_it_said_before_hanging(tmp_path):
+    enc = _encoder_running(tmp_path, _HANGING_CHILD)
+    with pytest.raises(RuntimeError) as excinfo:
+        enc.close(timeout=1.0)
+    message = str(excinfo.value)
+    assert "did not exit within 1.0s" in message, message
+    assert "WHY-IT-HUNG" in message, message
+
+
+@requires_ffmpeg
+def test_a_hung_encoder_that_said_nothing_says_so(tmp_path):
+    """An empty tail must not trail off the end of the message."""
+    enc = _encoder_running(tmp_path, _SILENT_HANGING_CHILD)
+    with pytest.raises(RuntimeError) as excinfo:
+        enc.close(timeout=1.0)
+    message = str(excinfo.value)
+    assert "did not exit within 1.0s" in message, message
+    assert "wrote nothing to stderr" in message, message
+
+
+@requires_ffmpeg
+def test_a_hung_encoder_is_killed_and_reaped(tmp_path):
+    """The timeout must not leave the process behind."""
+    enc = _encoder_running(tmp_path, _HANGING_CHILD)
+    proc = enc._proc
+    with pytest.raises(RuntimeError):
+        enc.close(timeout=1.0)
+    assert proc.poll() is not None, "the hung encoder outlived close()"
+    assert enc._proc is None
+    assert enc._stderr_file is None, "the stderr file was not released"
+
+
+@requires_ffmpeg
+def test_a_broken_pipe_on_close_does_not_hide_the_real_cause(tmp_path):
+    """ffmpeg died first, so closing its stdin fails.
+
+    Reporting that BrokenPipeError names a symptom and nothing else, and
+    it skipped the exit status and stderr that say what actually
+    happened.
+    """
+    enc = _encoder_running(tmp_path, _DYING_CHILD)
+    enc._proc.wait()
+
+    def boom():
+        raise BrokenPipeError(32, "Broken pipe")
+
+    enc._proc.stdin.close = boom
+    with pytest.raises(RuntimeError) as excinfo:
+        enc.close(timeout=5.0)
+    message = str(excinfo.value)
+    assert "status 3" in message, message
+    assert "DIED-BECAUSE-OF-THIS" in message, message
+
+
+@requires_ffmpeg
+def test_a_clean_close_still_raises_nothing(tmp_path):
+    """The ordinary path must be untouched."""
+    enc = _encoder_running(tmp_path, "import sys\nsys.stdin.buffer.read()\n")
+    enc.close(timeout=10.0)
+    assert enc._proc is None
+    assert enc._stderr_file is None


### PR DESCRIPTION
## The timeout path threw away the diagnostics

```python
except subprocess.TimeoutExpired:
    self._proc.kill()
    self._proc.wait()
    raise RuntimeError("ffmpeg did not exit within {}s".format(timeout))
finally:
    err = self._drain_stderr()      # computed, then dropped on the floor
```

That is the one failure where ffmpeg's own words matter most — it hung, and it
gets killed, so afterwards there is nothing left to ask — and it was the one
failure that arrived with none. The tail is now in the message, drained before
the `finally` closes the file:

```
ffmpeg did not exit within 1.0s and was killed: WHY-IT-HUNG
```

## A broken pipe was a second way to lose the cause

ffmpeg dying first makes `stdin.close()` fail, and the `BrokenPipeError`
propagated as-is — a symptom that names nothing, raised *in place of* the exit
status and stderr that say what actually happened. It is now swallowed so those
can do the talking:

```
ffmpeg exited with status 3: DIED-BECAUSE-OF-THIS
```

## Silence is now stated

Both empty-stderr cases say `(ffmpeg wrote nothing to stderr)` rather than
trailing an empty string off the end of a sentence. With `-loglevel error` a
clean run writes nothing, so silence is expected — but a message ending in
`status 1: ` leaves the reader unable to tell a quiet ffmpeg from a truncated
message.

## Verification

`docker compose run --rm test` → **370 passed** (was 365).

Control, against the committed fix — timeout message reverted to the bare
version and the `BrokenPipeError` catch disabled → **3 failed**:
`test_a_hung_encoder_reports_what_it_said_before_hanging`,
`test_a_hung_encoder_that_said_nothing_says_so`,
`test_a_broken_pipe_on_close_does_not_hide_the_real_cause`.

`test_a_hung_encoder_is_killed_and_reaped` and `test_a_clean_close_still_raises_nothing`
kept passing under the control, which is what shows the change is confined to
what the errors say rather than to the teardown itself.
