### PR TITLE
recording: fix two regressions in the output-claim check

### DIFF
--- a/fastgrab/recording/cli.py
+++ b/fastgrab/recording/cli.py
@@ -301,6 +301,31 @@ def _stdout_countdown():
     return _cb
 
 
+def _missing_output(output):
+    """The local file ffmpeg should have written, if it is absent.
+
+    Returns ``None`` when there is nothing to complain about -- either the
+    file is there, or the destination is not a local file at all.
+
+    ffmpeg accepts protocol URLs as outputs, so the configured string is
+    not always a path. ``file:`` names a local path with the prefix
+    stripped; it exists precisely so a filename containing a colon, or
+    one starting with a dash, can be given unambiguously. Anything else
+    carrying a scheme (``rtmp://``, ``tcp://``, ``pipe:``) is not on this
+    filesystem and there is nothing to look for. Checking the raw string
+    failed a perfectly good recording: ``-o file:out.mp4`` writes
+    ``out.mp4``, and os.path.exists never found it under that name.
+    """
+    if output.startswith("file:"):
+        output = output[len("file:"):]
+    else:
+        scheme = output.split(":", 1)[0]
+        # A single-letter scheme is a Windows drive, not a protocol.
+        if ":" in output and len(scheme) > 1 and scheme.isalpha():
+            return None
+    return None if os.path.exists(output) else output
+
+
 def main(argv=None):
     parser = build_parser()
     args = parser.parse_args(argv)
@@ -406,14 +431,19 @@ def main(argv=None):
     if stats is None:
         return 0
 
-    if stats.get("written_frames", stats["frames"]) == 0:
+    if not stats.get("encoder_started", True):
         # Ctrl-C during the countdown stops the recorder before ffmpeg is
-        # ever started, so there is no file. Reporting that as
-        # "wrote <path>: 0 frames" -- which is what the summary below
-        # does -- sent a script off to open something that was never
-        # created, and the failure then surfaced far from its cause.
-        # Cancelling deliberately is not an error, so the exit status
-        # stays 0, matching the selection- and dialog-cancel paths above.
+        # ever started, so there is genuinely no file. Reporting that as
+        # "wrote <path>: 0 frames" sent a script off to open something
+        # that was never created. Cancelling deliberately is not an
+        # error, so the exit status stays 0, matching the selection- and
+        # dialog-cancel paths above.
+        #
+        # Keyed on whether the encoder ran, not on the frame count: if
+        # the loop is stopped after ffmpeg starts but before the first
+        # capture, ffmpeg writes and closes an empty container quite
+        # happily -- 261 bytes for mp4, 465 for webm -- so zero frames
+        # and no file are different things.
         print(
             "fastgrab: cancelled before the first frame; {} was not "
             "written".format(stats["output"]),
@@ -421,13 +451,14 @@ def main(argv=None):
         )
         return 0
 
-    if not os.path.exists(stats["output"]):
+    missing = _missing_output(stats["output"])
+    if missing is not None:
         # Frames went to ffmpeg and it exited cleanly, yet nothing is
         # there. Whatever the cause, saying "wrote" would be a lie of the
         # same kind, so fail rather than describe a file that is absent.
         print(
             "error: {} frames were encoded but {} does not exist".format(
-                stats["frames"], stats["output"]
+                stats["frames"], missing
             ),
             file=sys.stderr,
         )

--- a/fastgrab/recording/recorder.py
+++ b/fastgrab/recording/recorder.py
@@ -137,6 +137,7 @@ class Recorder:
                         "elapsed_seconds": 0.0,
                         "achieved_fps": 0.0,
                         "output": self.output_path,
+                        "encoder_started": False,
                     }
                 if on_countdown is not None:
                     on_countdown(remaining)
@@ -210,4 +211,11 @@ class Recorder:
             "elapsed_seconds": elapsed,
             "achieved_fps": (n_captured / elapsed) if elapsed > 0 else 0.0,
             "output": self.output_path,
+            # Whether ffmpeg ran at all. This is the *only* honest way to
+            # know whether an output file can exist: a zero-frame mp4 or
+            # webm is written and closed cleanly by ffmpeg -- 261 and 465
+            # bytes of empty container respectively -- so a frame count
+            # of nought does not mean nothing was produced. Only the
+            # countdown's early return above guarantees that.
+            "encoder_started": True,
         }

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -906,19 +906,22 @@ def _run_cli_with(monkeypatch, stats, tmp_path, extra=None):
     return recording_cli.main(argv + (extra or []))
 
 
-def _stats(output, frames=0, written=0):
+def _stats(output, frames=0, written=0, encoder_started=True):
     return {
         "frames": frames,
         "written_frames": written,
         "elapsed_seconds": 0.0 if not frames else 1.0,
         "achieved_fps": 0.0 if not frames else float(frames),
         "output": str(output),
+        "encoder_started": encoder_started,
     }
 
 
 def test_a_cancelled_recording_does_not_claim_a_file(monkeypatch, tmp_path, capsys):
     out = tmp_path / "out.mp4"
-    rc = _run_cli_with(monkeypatch, _stats(out), tmp_path)
+    rc = _run_cli_with(
+        monkeypatch, _stats(out, encoder_started=False), tmp_path
+    )
     captured = capsys.readouterr()
     assert rc == 0, "a deliberate cancel is not an error"
     assert "wrote" not in captured.out, captured.out
@@ -1236,3 +1239,94 @@ def test_a_clean_close_still_raises_nothing(tmp_path):
     enc.close(timeout=10.0)
     assert enc._proc is None
     assert enc._stderr_file is None
+
+
+# -------- two regressions the first version of this check introduced --------
+#
+# Both found by review of the merged change, and both confirmed by
+# running ffmpeg rather than by reading the code.
+
+def test_zero_frames_with_a_started_encoder_is_not_a_cancellation(
+    monkeypatch, tmp_path, capsys
+):
+    """A frame count of nought does not mean nothing was produced.
+
+    If the loop stops after ffmpeg starts but before the first capture,
+    ffmpeg writes and closes an empty container quite happily — measured
+    at 261 bytes for mp4 and 465 for webm, both with a clean exit. The
+    first version of this branch keyed on the frame count and so
+    announced that a file which exists "was not written", which is the
+    same lie it was added to prevent, pointing the other way.
+    """
+    out = tmp_path / "out.mp4"
+    out.write_bytes(b"\0" * 261)  # what ffmpeg leaves behind
+    rc = _run_cli_with(
+        monkeypatch, _stats(out, frames=0, written=0, encoder_started=True),
+        tmp_path,
+    )
+    captured = capsys.readouterr()
+    assert rc == 0
+    assert "was not written" not in captured.err, captured.err
+    assert "wrote {}".format(out) in captured.out, captured.out
+
+
+def test_a_file_url_output_is_resolved_before_looking_for_it(
+    monkeypatch, tmp_path, capsys
+):
+    """`-o file:out.mp4` writes out.mp4; the check must not fail it.
+
+    ffmpeg's file: protocol exists so a name containing a colon, or one
+    starting with a dash, can be given unambiguously. Confirmed against
+    real ffmpeg: `file:/tmp/url.mp4` produced /tmp/url.mp4 and exited
+    cleanly, while os.path.exists on the raw string was False — so the
+    first version of this check failed a recording that had worked.
+    """
+    real = tmp_path / "out.mp4"
+    real.write_bytes(b"a real recording")
+    rc = _run_cli_with(
+        monkeypatch, _stats("file:" + str(real), frames=10, written=10),
+        tmp_path,
+    )
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+    assert "does not exist" not in captured.err
+    assert "wrote file:{}".format(real) in captured.out, captured.out
+
+
+def test_a_non_file_destination_is_not_checked_on_disk(
+    monkeypatch, tmp_path, capsys
+):
+    """ffmpeg can write to a protocol URL; there is no path to stat."""
+    rc = _run_cli_with(
+        monkeypatch, _stats("rtmp://example.invalid/live/x.mp4",
+                            frames=10, written=10),
+        tmp_path,
+    )
+    captured = capsys.readouterr()
+    assert rc == 0, captured.err
+    assert "does not exist" not in captured.err
+
+
+def test_a_genuinely_missing_local_file_is_still_an_error(
+    monkeypatch, tmp_path, capsys
+):
+    """The check must keep working for the ordinary case."""
+    out = tmp_path / "gone.mp4"
+    rc = _run_cli_with(monkeypatch, _stats(out, frames=10, written=10), tmp_path)
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "does not exist" in captured.err
+
+
+def test_a_missing_file_url_target_is_reported_by_its_real_path(
+    monkeypatch, tmp_path, capsys
+):
+    """Resolving must not turn a real failure into a pass."""
+    out = tmp_path / "gone.mp4"
+    rc = _run_cli_with(
+        monkeypatch, _stats("file:" + str(out), frames=10, written=10), tmp_path
+    )
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert str(out) in captured.err
+    assert "file:" not in captured.err, "report the path ffmpeg writes, not the URL"


### PR DESCRIPTION
Two regressions **introduced by #64**, found by review of the merged change and
confirmed by running ffmpeg rather than by reading the code.

## 1. Zero frames does not mean no file

The cancellation branch keyed on the frame count. If the loop stops after ffmpeg
starts but before the first capture — a fast Ctrl-C, or a duration already
elapsed — ffmpeg writes and closes an empty container quite happily:

```
mp4   close() -> clean exit (0)   file exists=True size=261
webm  close() -> clean exit (0)   file exists=True size=465
gif   close() -> RuntimeError: status 234 (trailer)   size=0
```

So the branch announced that a file which *exists* "was not written" — the same
lie #64 was written to prevent, pointing the other way.

Only the countdown's early return guarantees ffmpeg never ran, so the recorder
now says so directly with an `encoder_started` key and the CLI keys on that. gif
is unaffected either way: zero frames there is a trailer error, which already
surfaces through the normal failure path.

## 2. The output string is not always a path

The existence check ran `os.path.exists` on the configured output. ffmpeg accepts
protocol URLs, and `file:` names a local path with the prefix stripped — it
exists precisely so a filename containing a colon, or one starting with a dash,
can be given unambiguously.

```
-o /tmp/plain.mp4     close=ok  os.path.exists(literal)=True   real file exists=True
-o file:/tmp/url.mp4  close=ok  os.path.exists(literal)=False  real file exists=True
```

That second row is a **successful recording failed with exit 1**. The path is now
resolved first, other schemes are left alone (there is nothing local to look
for), and a missing `file:` target is reported by the path ffmpeg writes rather
than by the URL. A single-letter scheme is treated as a Windows drive, not a
protocol.

## Verification

`docker compose run --rm test` → **375 passed** (was 370).

End to end:

```
plain path, 1s duration     rc=0  file=1871   wrote /tmp/e.mp4: 10 frames
file: URL, 1s duration      rc=0  file=1871   wrote file:/tmp/e.mp4: 10 frames
SIGINT during countdown     rc=0  file=MISSING
                                  fastgrab: cancelled before the first frame; ...
SIGINT mid-record           rc=0  file=2228   wrote /tmp/e.mp4: 23 frames
```

Control, against the committed fix — both keyed the way #64 had them → **4 failed**:
`test_zero_frames_with_a_started_encoder_is_not_a_cancellation`,
`test_a_file_url_output_is_resolved_before_looking_for_it`,
`test_a_non_file_destination_is_not_checked_on_disk`,
`test_a_missing_file_url_target_is_reported_by_its_real_path`.

The tests covering the ordinary paths — a genuine cancellation, a genuinely
missing local file, a normal recording — kept passing under the control.
