### PR TITLE
recording: make Ctrl-C outside the recording loop behave

### DIFF
--- a/fastgrab/recording/cli.py
+++ b/fastgrab/recording/cli.py
@@ -327,6 +327,28 @@ def _missing_output(output):
 
 
 def main(argv=None):
+    """Entry point for ``fastgrab-record``.
+
+    Only job beyond calling :func:`_main` is to keep a Ctrl-C from ending
+    the command with a traceback. The recording loop installs its own
+    SIGINT handler, but everything before that -- imports, argument
+    parsing, the interactive region selector, the config dialog -- runs
+    under Python's default one, and there a Ctrl-C raises. Aborting is
+    the right response; the traceback is only noise. Deliberately not
+    solved by installing the handler sooner: that would swap the noise
+    for a setup phase that ignores Ctrl-C, which is worse.
+    """
+    try:
+        return _main(argv)
+    except KeyboardInterrupt:
+        # 130 is the shell's conventional status for a program ended by
+        # SIGINT, and what bash reports for a child killed by one, so
+        # scripts see no change from the previous behaviour.
+        print("fastgrab: interrupted", file=sys.stderr)
+        return 130
+
+
+def _main(argv=None):
     parser = build_parser()
     args = parser.parse_args(argv)
 
@@ -395,11 +417,17 @@ def main(argv=None):
     def _on_signal(_signum, _frame):
         stop_event.set()
 
-    signal.signal(signal.SIGINT, _on_signal)
-    signal.signal(signal.SIGTERM, _on_signal)
+    # Restored once recording is over. Left installed, they would swallow
+    # a Ctrl-C during the summary below -- setting an event nothing reads
+    # any more, so the command could not be interrupted at all -- and
+    # main() is importable and reachable as a library call, which has no
+    # business permanently changing the process's signal disposition.
+    previous_handlers = {}
 
     progress_cb = None
     try:
+        for signum in (signal.SIGINT, signal.SIGTERM):
+            previous_handlers[signum] = signal.signal(signum, _on_signal)
         if args.gui:
             # Launched from a hotkey there's no terminal to print to, so
             # show a small window with the live frame count. It stays open
@@ -422,6 +450,9 @@ def main(argv=None):
             sys.stdout.write("\n")
         print("error: {}".format(exc), file=sys.stderr)
         return 1
+    finally:
+        for signum, handler in previous_handlers.items():
+            signal.signal(signum, handler)
 
     if progress_cb is not None:
         # Close off the in-place status line so the summary starts fresh.

--- a/tests/test_recording.py
+++ b/tests/test_recording.py
@@ -8,6 +8,7 @@ inside ``docker compose run --rm test``.
 import argparse
 import os
 import shutil
+import signal
 import subprocess
 import sys
 import tempfile
@@ -1330,3 +1331,110 @@ def test_a_missing_file_url_target_is_reported_by_its_real_path(
     assert rc == 1
     assert str(out) in captured.err
     assert "file:" not in captured.err, "report the path ffmpeg writes, not the URL"
+
+
+# -------- Ctrl-C outside the recording loop --------
+#
+# The loop installs its own SIGINT handler so a stop finalises the
+# container. Everything around it did not behave:
+#
+#   * before the handler is installed — argument parsing, the region
+#     selector, the config dialog — Ctrl-C ended the command with a bare
+#     KeyboardInterrupt traceback. The selector is the case that matters:
+#     it can sit open for as long as the user takes to drag a box.
+#     (One window stays: the ~0.22s of module import, measured, which
+#     happens before main() is called and so before any code here can
+#     catch anything. A SIGINT at 0.2s still ends in a traceback; at 0.6s
+#     it does not.)
+#   * after record() returns, the handler was still installed, so a
+#     Ctrl-C during the summary set an event nothing reads any more and
+#     the command could not be interrupted at all.
+#   * main() is importable and reachable as a library call, and it left
+#     the process's signal disposition permanently changed.
+#
+# Installing the handler earlier would fix only the first, and would buy
+# it by making the interactive setup ignore Ctrl-C, which is worse.
+
+
+def test_an_interrupt_before_recording_exits_cleanly(monkeypatch, tmp_path, capsys):
+    """No traceback, and the shell's conventional status for SIGINT."""
+
+    def interrupted(**kwargs):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(recording_cli, "Recorder", interrupted)
+    try:
+        rc = recording_cli.main(
+            ["--region", "0,0,64,48", "-o", str(tmp_path / "out.mp4")]
+        )
+    except KeyboardInterrupt:
+        # Caught here on purpose. pytest treats a KeyboardInterrupt as a
+        # request to abandon the session, so letting one escape would
+        # abort the whole run at whatever point this test happens to sit
+        # rather than reporting which behaviour regressed.
+        pytest.fail("main() let the KeyboardInterrupt escape to the caller")
+    captured = capsys.readouterr()
+    assert rc == 130, "130 is what bash reports for a child killed by SIGINT"
+    assert "fastgrab: interrupted" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_the_signal_handlers_are_restored_after_recording(monkeypatch, tmp_path):
+    """Left installed, they swallow a Ctrl-C during the summary."""
+    out = tmp_path / "out.mp4"
+    out.write_bytes(b"x")
+    before = (signal.getsignal(signal.SIGINT), signal.getsignal(signal.SIGTERM))
+
+    rc = _run_cli_with(monkeypatch, _stats(out, frames=5, written=5), tmp_path)
+
+    assert rc == 0
+    assert (signal.getsignal(signal.SIGINT),
+            signal.getsignal(signal.SIGTERM)) == before
+
+
+def test_the_signal_handlers_are_restored_when_recording_fails(
+    monkeypatch, tmp_path
+):
+    """The restore has to survive the error path too."""
+    before = (signal.getsignal(signal.SIGINT), signal.getsignal(signal.SIGTERM))
+
+    class _Failing:
+        def record(self, **kwargs):
+            raise RuntimeError("ffmpeg fell over")
+
+    monkeypatch.setattr(recording_cli, "Recorder", lambda **kw: _Failing())
+    rc = recording_cli.main(
+        ["--region", "0,0,64,48", "-o", str(tmp_path / "out.mp4")]
+    )
+
+    assert rc == 1
+    assert (signal.getsignal(signal.SIGINT),
+            signal.getsignal(signal.SIGTERM)) == before
+
+
+def test_the_handler_is_installed_while_recording(monkeypatch, tmp_path):
+    """The restore must not undo the thing it is restoring around.
+
+    A Ctrl-C mid-recording still has to set the stop event rather than
+    raise, or ffmpeg loses the chance to write its trailer.
+    """
+    out = tmp_path / "out.mp4"
+    out.write_bytes(b"x")
+    seen = {}
+
+    class _Watching:
+        def record(self, stop_event=None, **kwargs):
+            seen["handler"] = signal.getsignal(signal.SIGINT)
+            seen["default"] = signal.default_int_handler
+            # what a real SIGINT would do at this moment
+            seen["handler"](signal.SIGINT, None)
+            seen["stopped"] = stop_event.is_set()
+            return _stats(out, frames=5, written=5)
+
+    monkeypatch.setattr(recording_cli, "Recorder", lambda **kw: _Watching())
+    rc = recording_cli.main(
+        ["--region", "0,0,64,48", "-o", str(out)]
+    )
+    assert rc == 0
+    assert seen["handler"] is not seen["default"], "the loop ran unprotected"
+    assert seen["stopped"], "a Ctrl-C mid-recording did not ask it to stop"


### PR DESCRIPTION
The recording loop installs its own SIGINT handler so a stop lets ffmpeg finalise
the container. Everything *around* it did not behave — in three ways, only one of
which I had noticed when I flagged this during #64.

## 1. A Ctrl-C before the handler is installed gave a traceback

Argument parsing, the interactive region selector, the config dialog. The
selector is the case that matters: it sits open for as long as the user takes to
drag a box, and a Ctrl-C there ended the command with a bare
`KeyboardInterrupt` traceback.

`main()` now catches it, prints `fastgrab: interrupted` and returns **130** — the
shell's conventional status for a program ended by SIGINT, and what bash already
reported for a child killed by one, so scripts see no change.

**Deliberately not solved by installing the handler sooner.** That would swap a
traceback for a setup phase that ignores Ctrl-C entirely, since the event it sets
is read only by the recording loop. Worse trade.

### The window that remains

Importing the module takes **~0.22s** (numpy, mostly) and runs before `main()` is
called, so nothing here can catch a Ctrl-C during it. Measured rather than
assumed:

```
SIGINT at 0.2s -> rc=-2  import finished first=False  traceback=True
SIGINT at 0.6s -> rc=0   import finished first=True   traceback=False
SIGINT at 1.2s -> rc=0   import finished first=True   traceback=False
```

## 2. The handlers were never removed — so Ctrl-C stopped working

After `record()` returned they stayed installed, so a Ctrl-C while the summary
printed set an event nothing reads any more. The command could not be
interrupted at all. They are now restored in a `finally`, which also covers the
error path.

## 3. `main()` permanently changed the process's signal disposition

It is importable and reachable as a library call (`fastgrab.recording.cli:main`
is the console-script entry). It had no business leaving its handlers behind —
which is why the restore belongs in a `finally` rather than at the end.

## Verification

`docker compose run --rm test` → **379 passed** (was 375).

End to end against the real CLI:

```
SIGINT during countdown   rc=0  traceback=False  cancelled before the first frame
SIGINT mid-record         rc=0  traceback=False  wrote /tmp/s.mp4: 23 frames
SIGINT x2 mid-record      rc=0  traceback=False  wrote /tmp/s.mp4: 23 frames
SIGTERM mid-record        rc=0  traceback=False  wrote /tmp/s.mp4: 23 frames
clean 1s run              rc=0  traceback=False  wrote /tmp/s.mp4: 10 frames
```

Controls, each against the committed fix:

- `KeyboardInterrupt` catch removed → **1 failed**
  (`test_an_interrupt_before_recording_exits_cleanly`)
- handler restore removed → **2 failed**
  (`..._restored_after_recording`, `..._restored_when_recording_fails`)

One note from running the first control: it initially collapsed the suite to
**157 passed** rather than reporting a failure, because pytest treats an escaping
`KeyboardInterrupt` as a request to abandon the session. A regression would have
aborted CI partway with a confusing result instead of naming what broke, so the
test now catches the escape and calls `pytest.fail` — after which the control
reports a clean single failure.
